### PR TITLE
feat: Implement ledger-seeded nebula generation + dynamic rarity oracle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,21 +7,15 @@ description = "Decentralized space exploration sim on Stellar with procedural ne
 repository = "https://github.com/yourusername/stellar-nebula-nomad"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = { version = "0.20", features = ["derive"] }
-soroban-contract = "0.20"
+soroban-sdk = "22.0"
 
 [dev-dependencies]
-soroban-sdk = { version = "0.20", features = ["derive"] }
+soroban-sdk = { version = "22.0", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"
 lto = true
 codegen-units = 1
-
-[[bin]]
-name = "stellar_nebula_nomad"
-path = "src/lib.rs"
-crate-type = ["cdylib"]

--- a/README.md
+++ b/README.md
@@ -159,31 +159,37 @@ soroban contract invoke \
 
 ## 🏗️ Architecture
 
+### Nebula Generation Flow (Mermaid)
+
+```mermaid
+graph TD
+    A[Player / dApp] -->|seed + address| B[scan_nebula]
+    B --> C[generate_nebula_layout]
+    B --> D[calculate_rarity_tier]
+    C --> E["SHA-256(seed ‖ ledger_seq ‖ timestamp)"]
+    E --> F[XorShift64 PRNG]
+    F --> G["16×16 NebulaLayout (256 cells)"]
+    G --> D
+    D --> H{Rarity Score}
+    H -->|0–49| I[Common]
+    H -->|50–99| J[Uncommon]
+    H -->|100–149| K[Rare]
+    H -->|150–199| L[Epic]
+    H -->|200+| M[Legendary]
+    B --> N["Emit NebulaScanned Event (layout hash)"]
+```
+
 ### Contract Interaction Diagram
 
-```
-┌─────────────────────────────────────────────────────────┐
-│              Player / dApp Interface                    │
-└────────────────────┬────────────────────────────────────┘
-                     │
-        ┌────────────┼────────────┬──────────────┐
-        │            │            │              │
-        ▼            ▼            ▼              ▼
-   ┌─────────┐ ┌──────────┐ ┌──────────┐ ┌─────────┐
-   │ Nebula  │ │ Resource │ │   Ship   │ │Ledger   │
-   │Explorer │ │ Minter   │ │Registry  │ │(Seed)   │
-   └────┬────┘ └────┬─────┘ └────┬─────┘ └─────────┘
-        │           │            │
-        └───────────┼────────────┘
-                    │
-        ┌───────────▼──────────┐
-        │  Stellar Ledger      │
-        │  (State Storage)     │
-        └──────────────────────┘
-
-┌───────────────────────────────────────────────────────────┐
-│                  Stellar Mainnet / Futurenet              │
-└───────────────────────────────────────────────────────────┘
+```mermaid
+graph TB
+    Player["Player / dApp Interface"] --> NE[Nebula Explorer]
+    Player --> RM[Resource Minter]
+    Player --> SR[Ship Registry]
+    NE -->|reads| Ledger["Stellar Ledger (Seed + State)"]
+    RM --> Ledger
+    SR --> Ledger
+    Ledger --> Stellar["Stellar Mainnet / Futurenet"]
 ```
 
 ### Module Breakdown
@@ -209,12 +215,13 @@ stellar-nebula-nomad/
 
 ### Data Flow
 
-1. **Player initiates scan** → Ship sends region_id to contract
-2. **Contract seeds RNG** → Uses Soroban ledger sequence + region_id
-3. **Procedural generation** → Nebula properties calculated deterministically
-4. **Results returned** → Density, color, resource level stored
-5. **Resource minting** → Player can mint discovered resources
-6. **Ownership recorded** → Stellar ledger maintains immutable history
+1. **Player initiates scan** → Provides a 32-byte seed + authenticates via `require_auth`
+2. **Entropy mixing** → Contract SHA-256 hashes: `seed ‖ ledger_sequence ‖ timestamp`
+3. **Procedural generation** → XorShift64 PRNG fills a 16×16 grid of `NebulaCell` structs (type + energy)
+4. **Rarity calculation** → On-chain math scores rare cell density + energy → `Rarity` enum (Common → Legendary)
+5. **Event emission** → `NebulaScanned` event published with layout hash for off-chain indexing
+6. **Resource minting** → Player can mint discovered resources
+7. **Ownership recorded** → Stellar ledger maintains immutable history
 
 ---
 

--- a/examples/scan_example.rs
+++ b/examples/scan_example.rs
@@ -1,28 +1,41 @@
-// Example: Scanning a Nebula Region
+// Example: Ledger-Seeded Nebula Generation
 //
-// This example demonstrates how to call the scan_nebula contract function
-// from a Rust client application using the Soroban SDK.
-
-use soroban_sdk::{Client, Env};
+// This example demonstrates how the generate_nebula_layout and
+// calculate_rarity_tier contract functions work together.
+//
+// In production, the Soroban contract is invoked via CLI or a dApp frontend.
+// The test environment (shown in tests/) uses Env::default() for
+// deterministic local testing.
 
 fn main() {
-    // Initialize Soroban environment
-    let env = Env::default();
-    
-    // Example invocation (pseudo-code):
-    // let contract = NebulaContract::new(&env, contract_address);
-    // let scan_result = contract.scan_nebula(&env, region_id);
-    
-    // Expected output:
-    // NebulaScan {
-    //     region_id: 12345,
-    //     density: 67,
-    //     color: "magenta",
-    //     resources: "abundant",
-    //     timestamp: 1739609600
-    // }
-    
-    println!("Nebula Nomad Scan Example");
-    println!("Scanning region 12345...");
-    println!("Result: Magenta nebula with abundant resources");
+    println!("=== Stellar Nebula Nomad: Nebula Generation Example ===");
+    println!();
+    println!("Flow:");
+    println!("  1. Player provides a 32-byte seed (BytesN<32>)");
+    println!("  2. Contract hashes: SHA-256(seed || ledger_sequence || timestamp)");
+    println!("  3. XorShift64 PRNG generates a deterministic 16x16 cell grid");
+    println!("  4. Each cell gets a CellType and energy value");
+    println!("  5. calculate_rarity_tier scores the layout → Rarity enum");
+    println!("  6. NebulaScanned event emitted with layout hash");
+    println!();
+    println!("Cell type distribution:");
+    println!("  Empty       30%  |  energy base:  0");
+    println!("  Star        15%  |  energy base: 10");
+    println!("  Asteroid    15%  |  energy base:  5");
+    println!("  GasCloud    15%  |  energy base:  8");
+    println!("  StellarDust 10%  |  energy base: 15");
+    println!("  DarkMatter   8%  |  energy base: 25");
+    println!("  ExoticMatter 5%  |  energy base: 40");
+    println!("  Wormhole     2%  |  energy base: 60");
+    println!();
+    println!("Rarity scoring: rare_cells * 10 + energy_density");
+    println!("  Common     0-49   | Uncommon  50-99");
+    println!("  Rare     100-149  | Epic     150-199");
+    println!("  Legendary  200+");
+    println!();
+    println!("CLI invocation:");
+    println!("  soroban contract invoke --id CONTRACT_ID \\");
+    println!("    --fn scan_nebula \\");
+    println!("    --arg '{{\"bytes\": \"<64-hex-chars>\"}}' \\");
+    println!("    --arg '\"GABC...\"'");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,58 @@
 #![no_std]
 
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
+
+mod nebula_explorer;
+mod resource_minter;
+mod ship_registry;
+
+pub use nebula_explorer::{
+    calculate_rarity_tier, compute_layout_hash, generate_nebula_layout, CellType, NebulaCell,
+    NebulaLayout, Rarity, GRID_SIZE, TOTAL_CELLS,
+};
+pub use resource_minter::Resource;
+pub use ship_registry::Ship;
+
 #[contract]
+pub struct NebulaNomadContract;
 
 #[contractimpl]
+impl NebulaNomadContract {
+    /// Generate a 16×16 procedural nebula map using ledger-seeded PRNG.
+    ///
+    /// Combines the supplied `seed` with on-chain ledger sequence and
+    /// timestamp. The player must authorize the call.
+    pub fn generate_nebula_layout(
+        env: Env,
+        seed: BytesN<32>,
+        player: Address,
+    ) -> NebulaLayout {
+        player.require_auth();
+        nebula_explorer::generate_nebula_layout(&env, &seed, &player)
+    }
+
+    /// Calculate the rarity tier of a nebula layout using on-chain
+    /// verifiable math (no off-chain RNG).
+    pub fn calculate_rarity_tier(env: Env, layout: NebulaLayout) -> Rarity {
+        nebula_explorer::calculate_rarity_tier(&env, &layout)
+    }
+
+    /// Full scan: generates layout, calculates rarity, and emits a
+    /// `NebulaScanned` event containing the layout hash.
+    pub fn scan_nebula(
+        env: Env,
+        seed: BytesN<32>,
+        player: Address,
+    ) -> (NebulaLayout, Rarity) {
+        player.require_auth();
+
+        let layout = nebula_explorer::generate_nebula_layout(&env, &seed, &player);
+        let rarity = nebula_explorer::calculate_rarity_tier(&env, &layout);
+        let layout_hash = nebula_explorer::compute_layout_hash(&env, &layout);
+
+        nebula_explorer::emit_nebula_scanned(&env, &player, &layout_hash, &rarity);
+
+        (layout, rarity)
+    }
+}
 

--- a/src/nebula_explorer.rs
+++ b/src/nebula_explorer.rs
@@ -1,8 +1,213 @@
-use soroban_sdk::{contracttype, Env, String};
+use soroban_sdk::{contracttype, symbol_short, Address, Bytes, BytesN, Env, Vec};
+
+pub const GRID_SIZE: u32 = 16;
+pub const TOTAL_CELLS: u32 = GRID_SIZE * GRID_SIZE;
+
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub enum CellType {
+    Empty,
+    Star,
+    Asteroid,
+    GasCloud,
+    DarkMatter,
+    ExoticMatter,
+    StellarDust,
+    Wormhole,
+}
 
 #[derive(Clone)]
 #[contracttype]
+pub struct NebulaCell {
+    pub x: u32,
+    pub y: u32,
+    pub cell_type: CellType,
+    pub energy: u32,
+}
 
+#[derive(Clone)]
+#[contracttype]
+pub struct NebulaLayout {
+    pub width: u32,
+    pub height: u32,
+    pub cells: Vec<NebulaCell>,
+    pub seed: BytesN<32>,
+    pub timestamp: u64,
+    pub total_energy: u32,
+}
 
-/// Scan a nebula region using ledger-seeded procedural generation
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub enum Rarity {
+    Common,
+    Uncommon,
+    Rare,
+    Epic,
+    Legendary,
+}
+
+/// Deterministic XorShift64 PRNG for on-chain verifiable randomness.
+/// Uses only arithmetic operations—no off-chain RNG.
+struct Xorshift64(u64);
+
+impl Xorshift64 {
+    fn new(seed: u64) -> Self {
+        Self(if seed == 0 { 1 } else { seed })
+    }
+
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+}
+
+/// Combine the caller-supplied seed with on-chain ledger entropy.
+/// Returns a SHA-256 hash mixing seed + ledger_sequence + ledger_timestamp.
+fn compute_combined_hash(env: &Env, seed: &BytesN<32>) -> BytesN<32> {
+    let mut input = Bytes::new(env);
+    let seed_bytes: Bytes = seed.clone().into();
+    input.append(&seed_bytes);
+    input.append(&Bytes::from_slice(env, &env.ledger().sequence().to_be_bytes()));
+    input.append(&Bytes::from_slice(env, &env.ledger().timestamp().to_be_bytes()));
+    env.crypto().sha256(&input).into()
+}
+
+/// Extract a u64 PRNG seed from the first 8 bytes of a BytesN<32>.
+fn seed_from_hash(_env: &Env, hash: &BytesN<32>) -> u64 {
+    let bytes: Bytes = hash.clone().into();
+    let mut val: u64 = 0;
+    for i in 0..8u32 {
+        val = (val << 8) | (bytes.get(i).unwrap_or(0) as u64);
+    }
+    if val == 0 { 1 } else { val }
+}
+
+/// Map a random u64 value to a CellType with weighted distribution.
+fn cell_type_from_val(val: u64) -> CellType {
+    match val % 100 {
+        0..=29 => CellType::Empty,        // 30%
+        30..=44 => CellType::Star,         // 15%
+        45..=59 => CellType::Asteroid,     // 15%
+        60..=74 => CellType::GasCloud,     // 15%
+        75..=84 => CellType::StellarDust,  // 10%
+        85..=92 => CellType::DarkMatter,   //  8%
+        93..=97 => CellType::ExoticMatter, //  5%
+        _ => CellType::Wormhole,           //  2%
+    }
+}
+
+/// Compute energy for a cell based on its type and a random modifier.
+fn energy_for_cell(cell_type: &CellType, val: u64) -> u32 {
+    let base: u32 = match cell_type {
+        CellType::Empty => 0,
+        CellType::Star => 10,
+        CellType::Asteroid => 5,
+        CellType::GasCloud => 8,
+        CellType::StellarDust => 15,
+        CellType::DarkMatter => 25,
+        CellType::ExoticMatter => 40,
+        CellType::Wormhole => 60,
+    };
+    base + (val % 10) as u32
+}
+
+/// Generate a 16×16 procedural nebula map using ledger-seeded PRNG.
+///
+/// Combines the caller-supplied `seed` with the current ledger sequence and
+/// timestamp to produce deterministic, on-chain verifiable output.
+/// The `player` address is authenticated via `require_auth` and recorded
+/// in the emitted event for attribution.
+pub fn generate_nebula_layout(env: &Env, seed: &BytesN<32>, _player: &Address) -> NebulaLayout {
+    let combined = compute_combined_hash(env, seed);
+    let prng_seed = seed_from_hash(env, &combined);
+    let mut rng = Xorshift64::new(prng_seed);
+    let timestamp = env.ledger().timestamp();
+
+    let mut cells = Vec::new(env);
+    let mut total_energy: u32 = 0;
+
+    for y in 0..GRID_SIZE {
+        for x in 0..GRID_SIZE {
+            let type_val = rng.next();
+            let energy_val = rng.next();
+            let cell_type = cell_type_from_val(type_val);
+            let energy = energy_for_cell(&cell_type, energy_val);
+            total_energy += energy;
+            cells.push_back(NebulaCell {
+                x,
+                y,
+                cell_type,
+                energy,
+            });
+        }
+    }
+
+    NebulaLayout {
+        width: GRID_SIZE,
+        height: GRID_SIZE,
+        cells,
+        seed: combined,
+        timestamp,
+        total_energy,
+    }
+}
+
+/// Calculate rarity tier from a NebulaLayout using on-chain verifiable math.
+///
+/// Scores the layout based on the count of rare cells (DarkMatter,
+/// ExoticMatter, Wormhole) and average energy density. Returns one of five
+/// `Rarity` tiers from Common to Legendary.
+pub fn calculate_rarity_tier(_env: &Env, layout: &NebulaLayout) -> Rarity {
+    let mut rare_cells: u32 = 0;
+
+    for i in 0..layout.cells.len() {
+        if let Some(cell) = layout.cells.get(i) {
+            match cell.cell_type {
+                CellType::DarkMatter | CellType::ExoticMatter | CellType::Wormhole => {
+                    rare_cells += 1;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let energy_density = layout.total_energy / TOTAL_CELLS;
+    let rarity_score = rare_cells * 10 + energy_density;
+
+    match rarity_score {
+        0..=49 => Rarity::Common,
+        50..=99 => Rarity::Uncommon,
+        100..=149 => Rarity::Rare,
+        150..=199 => Rarity::Epic,
+        _ => Rarity::Legendary,
+    }
+}
+
+/// Compute a deterministic SHA-256 hash of a NebulaLayout for event emission.
+pub fn compute_layout_hash(env: &Env, layout: &NebulaLayout) -> BytesN<32> {
+    let mut input = Bytes::new(env);
+    let seed_bytes: Bytes = layout.seed.clone().into();
+    input.append(&seed_bytes);
+    input.append(&Bytes::from_slice(env, &layout.width.to_be_bytes()));
+    input.append(&Bytes::from_slice(env, &layout.height.to_be_bytes()));
+    input.append(&Bytes::from_slice(env, &layout.total_energy.to_be_bytes()));
+    input.append(&Bytes::from_slice(env, &layout.timestamp.to_be_bytes()));
+    input.append(&Bytes::from_slice(env, &layout.cells.len().to_be_bytes()));
+    env.crypto().sha256(&input).into()
+}
+
+/// Emit the NebulaScanned event with player address, layout hash, and rarity.
+pub fn emit_nebula_scanned(
+    env: &Env,
+    player: &Address,
+    layout_hash: &BytesN<32>,
+    rarity: &Rarity,
+) {
+    env.events().publish(
+        (symbol_short!("nebula"), symbol_short!("scanned")),
+        (player.clone(), layout_hash.clone(), rarity.clone()),
+    );
+}
 

--- a/src/resource_minter.rs
+++ b/src/resource_minter.rs
@@ -1,8 +1,12 @@
-use soroban_sdk::{contracttype, Env, String};
+use soroban_sdk::{contracttype, Address};
 
+/// Resource data structure for in-game tradeable resources.
 #[derive(Clone)]
 #[contracttype]
-
-
-/// Mint a new resource for a player
+pub struct Resource {
+    pub id: u64,
+    pub owner: Address,
+    pub resource_type: u32,
+    pub quantity: u32,
+}
 

--- a/src/ship_registry.rs
+++ b/src/ship_registry.rs
@@ -1,5 +1,13 @@
-use soroban_sdk::{contracttype, Env, String};
+use soroban_sdk::{contracttype, Address, String};
 
+/// Ship NFT data structure for explorer vessels.
 #[derive(Clone)]
 #[contracttype]
+pub struct Ship {
+    pub id: u64,
+    pub owner: Address,
+    pub name: String,
+    pub level: u32,
+    pub scan_range: u32,
+}
 

--- a/test_snapshots/test_different_seeds_produce_different_layouts.1.json
+++ b/test_snapshots/test_different_seeds_produce_different_layouts.1.json
@@ -1,0 +1,185 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_generate_layout_deterministic.1.json
+++ b/test_snapshots/test_generate_layout_deterministic.1.json
@@ -1,0 +1,185 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "0707070707070707070707070707070707070707070707070707070707070707"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "0707070707070707070707070707070707070707070707070707070707070707"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_generate_layout_dimensions.1.json
+++ b/test_snapshots/test_generate_layout_dimensions.1.json
@@ -1,0 +1,130 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_generate_layout_has_energy.1.json
+++ b/test_snapshots/test_generate_layout_has_energy.1.json
@@ -1,0 +1,130 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_layout_cell_coordinates.1.json
+++ b/test_snapshots/test_layout_cell_coordinates.1.json
@@ -1,0 +1,130 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_layout_changes_with_ledger_state.1.json
+++ b/test_snapshots/test_layout_changes_with_ledger_state.1.json
@@ -1,0 +1,185 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "0505050505050505050505050505050505050505050505050505050505050505"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "0505050505050505050505050505050505050505050505050505050505050505"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 200,
+    "timestamp": 2000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10199
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_layout_records_timestamp.1.json
+++ b/test_snapshots/test_layout_records_timestamp.1.json
@@ -1,0 +1,130 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_rarity_common.1.json
+++ b/test_snapshots/test_rarity_common.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_rarity_energy_density_contributes.1.json
+++ b/test_snapshots/test_rarity_energy_density_contributes.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_rarity_epic.1.json
+++ b/test_snapshots/test_rarity_epic.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_rarity_from_generated_layout.1.json
+++ b/test_snapshots/test_rarity_from_generated_layout.1.json
@@ -1,0 +1,131 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "6363636363636363636363636363636363636363636363636363636363636363"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_rarity_legendary.1.json
+++ b/test_snapshots/test_rarity_legendary.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_rarity_rare.1.json
+++ b/test_snapshots/test_rarity_rare.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_rarity_uncommon.1.json
+++ b/test_snapshots/test_rarity_uncommon.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test_scan_nebula_consistency_with_individual_calls.1.json
+++ b/test_snapshots/test_scan_nebula_consistency_with_individual_calls.1.json
@@ -1,0 +1,224 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "2121212121212121212121212121212121212121212121212121212121212121"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "scan_nebula",
+              "args": [
+                {
+                  "bytes": "2121212121212121212121212121212121212121212121212121212121212121"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "nebula"
+              },
+              {
+                "symbol": "scanned"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "6646930a65d5440f0e04d41f9e90479917b5a4d3101be9971adb58329bb15a1d"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "Legendary"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/test_snapshots/test_scan_nebula_emits_event.1.json
+++ b/test_snapshots/test_scan_nebula_emits_event.1.json
@@ -1,0 +1,168 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "scan_nebula",
+              "args": [
+                {
+                  "bytes": "4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "nebula"
+              },
+              {
+                "symbol": "scanned"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "fe1f3b9170f6c7627eef56ec07d1dd61f63bd221730deb5ead7b8677da2586dc"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "Legendary"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/test_snapshots/test_scan_nebula_returns_layout_and_rarity.1.json
+++ b/test_snapshots/test_scan_nebula_returns_layout_and_rarity.1.json
@@ -1,0 +1,168 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "scan_nebula",
+              "args": [
+                {
+                  "bytes": "3232323232323232323232323232323232323232323232323232323232323232"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "nebula"
+              },
+              {
+                "symbol": "scanned"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "f0449213cf3766d98ec808bd285f6443cc056f6dbd16c60f638ea962d53ded0e"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "Legendary"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/test_snapshots/test_zero_seed_works.1.json
+++ b/test_snapshots/test_zero_seed_works.1.json
@@ -1,0 +1,130 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "generate_nebula_layout",
+              "args": [
+                {
+                  "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 100,
+    "timestamp": 1700000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 10,
+    "min_persistent_entry_ttl": 1000,
+    "min_temp_entry_ttl": 100,
+    "max_entry_ttl": 10000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          10099
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          1099
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,281 @@
 #![cfg(test)]
 
-#[cfg(test)]
+use soroban_sdk::testutils::{Address as _, Events, Ledger, LedgerInfo};
+use soroban_sdk::{vec, Address, BytesN, Env, IntoVal, Val, Vec};
+use stellar_nebula_nomad::{
+    CellType, NebulaNomadContract, NebulaNomadContractClient, NebulaCell, NebulaLayout, Rarity,
+    GRID_SIZE, TOTAL_CELLS,
+};
+
+fn setup_env() -> (Env, NebulaNomadContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set(LedgerInfo {
+        protocol_version: 22,
+        sequence_number: 100,
+        timestamp: 1_700_000_000,
+        network_id: [0u8; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 100,
+        min_persistent_entry_ttl: 1000,
+        max_entry_ttl: 10_000,
+    });
+    let contract_id = env.register_contract(None, NebulaNomadContract);
+    let client = NebulaNomadContractClient::new(&env, &contract_id);
+    let player = Address::generate(&env);
+    (env, client, player)
+}
+
+// ─── generate_nebula_layout ───────────────────────────────────────────────
+
+#[test]
+fn test_generate_layout_dimensions() {
+    let (env, client, player) = setup_env();
+    let seed = BytesN::from_array(&env, &[1u8; 32]);
+    let layout = client.generate_nebula_layout(&seed, &player);
+    assert_eq!(layout.width, GRID_SIZE);
+    assert_eq!(layout.height, GRID_SIZE);
+    assert_eq!(layout.cells.len(), TOTAL_CELLS);
+}
+
+#[test]
+fn test_generate_layout_has_energy() {
+    let (env, client, player) = setup_env();
+    let seed = BytesN::from_array(&env, &[42u8; 32]);
+    let layout = client.generate_nebula_layout(&seed, &player);
+    assert!(layout.total_energy > 0);
+}
+
+#[test]
+fn test_generate_layout_deterministic() {
+    let (env, client, player) = setup_env();
+    let seed = BytesN::from_array(&env, &[7u8; 32]);
+    let layout1 = client.generate_nebula_layout(&seed, &player);
+    let layout2 = client.generate_nebula_layout(&seed, &player);
+    assert_eq!(layout1.total_energy, layout2.total_energy);
+    assert_eq!(layout1.seed, layout2.seed);
+    assert_eq!(layout1.timestamp, layout2.timestamp);
+}
+
+#[test]
+fn test_different_seeds_produce_different_layouts() {
+    let (env, client, player) = setup_env();
+    let seed_a = BytesN::from_array(&env, &[1u8; 32]);
+    let seed_b = BytesN::from_array(&env, &[2u8; 32]);
+    let layout_a = client.generate_nebula_layout(&seed_a, &player);
+    let layout_b = client.generate_nebula_layout(&seed_b, &player);
+    assert_ne!(layout_a.total_energy, layout_b.total_energy);
+}
+
+#[test]
+fn test_layout_changes_with_ledger_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, NebulaNomadContract);
+    let client = NebulaNomadContractClient::new(&env, &contract_id);
+    let player = Address::generate(&env);
+    let seed = BytesN::from_array(&env, &[5u8; 32]);
+
+    env.ledger().set(LedgerInfo {
+        protocol_version: 22,
+        sequence_number: 100,
+        timestamp: 1_000_000,
+        network_id: [0u8; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 100,
+        min_persistent_entry_ttl: 1000,
+        max_entry_ttl: 10_000,
+    });
+    let layout1 = client.generate_nebula_layout(&seed, &player);
+
+    env.ledger().set(LedgerInfo {
+        protocol_version: 22,
+        sequence_number: 200,
+        timestamp: 2_000_000,
+        network_id: [0u8; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 100,
+        min_persistent_entry_ttl: 1000,
+        max_entry_ttl: 10_000,
+    });
+    let layout2 = client.generate_nebula_layout(&seed, &player);
+
+    assert_ne!(layout1.total_energy, layout2.total_energy);
+}
+
+#[test]
+fn test_layout_cell_coordinates() {
+    let (env, client, player) = setup_env();
+    let seed = BytesN::from_array(&env, &[10u8; 32]);
+    let layout = client.generate_nebula_layout(&seed, &player);
+
+    for i in 0..layout.cells.len() {
+        let cell = layout.cells.get(i).unwrap();
+        assert!(cell.x < GRID_SIZE);
+        assert!(cell.y < GRID_SIZE);
+    }
+}
+
+#[test]
+fn test_layout_records_timestamp() {
+    let (env, client, player) = setup_env();
+    let seed = BytesN::from_array(&env, &[3u8; 32]);
+    let layout = client.generate_nebula_layout(&seed, &player);
+    assert_eq!(layout.timestamp, 1_700_000_000);
+}
+
+#[test]
+fn test_zero_seed_works() {
+    let (env, client, player) = setup_env();
+    let seed = BytesN::from_array(&env, &[0u8; 32]);
+    let layout = client.generate_nebula_layout(&seed, &player);
+    assert_eq!(layout.cells.len(), TOTAL_CELLS);
+}
+
+// ─── calculate_rarity_tier ────────────────────────────────────────────────
+
+fn make_layout(env: &Env, rare_count: u32, energy_per_cell: u32) -> NebulaLayout {
+    let mut cells = Vec::new(env);
+    let mut total_energy = 0u32;
+    for i in 0..TOTAL_CELLS {
+        let (cell_type, energy) = if i < rare_count {
+            (CellType::Wormhole, 60 + energy_per_cell)
+        } else {
+            (CellType::Empty, energy_per_cell)
+        };
+        total_energy += energy;
+        cells.push_back(NebulaCell {
+            x: i % GRID_SIZE,
+            y: i / GRID_SIZE,
+            cell_type,
+            energy,
+        });
+    }
+    NebulaLayout {
+        width: GRID_SIZE,
+        height: GRID_SIZE,
+        cells,
+        seed: BytesN::from_array(env, &[0u8; 32]),
+        timestamp: 0,
+        total_energy,
+    }
+}
+
+#[test]
+fn test_rarity_common() {
+    let (env, client, _) = setup_env();
+    let layout = make_layout(&env, 0, 0);
+    let rarity = client.calculate_rarity_tier(&layout);
+    assert_eq!(rarity, Rarity::Common);
+}
+
+#[test]
+fn test_rarity_uncommon() {
+    let (env, client, _) = setup_env();
+    // 5 rare cells × 10 = 50, energy_density ≈ 0 → score 50 → Uncommon
+    let layout = make_layout(&env, 5, 0);
+    let rarity = client.calculate_rarity_tier(&layout);
+    assert_eq!(rarity, Rarity::Uncommon);
+}
+
+#[test]
+fn test_rarity_rare() {
+    let (env, client, _) = setup_env();
+    // 10 rare cells × 10 = 100 → score 100 → Rare
+    let layout = make_layout(&env, 10, 0);
+    let rarity = client.calculate_rarity_tier(&layout);
+    assert_eq!(rarity, Rarity::Rare);
+}
+
+#[test]
+fn test_rarity_epic() {
+    let (env, client, _) = setup_env();
+    // 15 rare cells × 10 = 150 → score 150 → Epic
+    let layout = make_layout(&env, 15, 0);
+    let rarity = client.calculate_rarity_tier(&layout);
+    assert_eq!(rarity, Rarity::Epic);
+}
+
+#[test]
+fn test_rarity_legendary() {
+    let (env, client, _) = setup_env();
+    // 20 rare cells × 10 = 200 → score 200 → Legendary
+    let layout = make_layout(&env, 20, 0);
+    let rarity = client.calculate_rarity_tier(&layout);
+    assert_eq!(rarity, Rarity::Legendary);
+}
+
+#[test]
+fn test_rarity_energy_density_contributes() {
+    let (env, client, _) = setup_env();
+    // 4 rare cells × 10 = 40, with high energy per cell to push into Uncommon
+    // energy_per_cell = 10 → total = 256 * 10 = 2560, density = 10 → score = 50
+    let layout = make_layout(&env, 4, 10);
+    let rarity = client.calculate_rarity_tier(&layout);
+    assert_eq!(rarity, Rarity::Uncommon);
+}
+
+#[test]
+fn test_rarity_from_generated_layout() {
+    let (env, client, player) = setup_env();
+    let seed = BytesN::from_array(&env, &[99u8; 32]);
+    let layout = client.generate_nebula_layout(&seed, &player);
+    let rarity = client.calculate_rarity_tier(&layout);
+    // Should be one of the valid rarity tiers
+    assert!(
+        rarity == Rarity::Common
+            || rarity == Rarity::Uncommon
+            || rarity == Rarity::Rare
+            || rarity == Rarity::Epic
+            || rarity == Rarity::Legendary
+    );
+}
+
+// ─── scan_nebula (end-to-end + event emission) ───────────────────────────
+
+#[test]
+fn test_scan_nebula_returns_layout_and_rarity() {
+    let (env, client, player) = setup_env();
+    let seed = BytesN::from_array(&env, &[50u8; 32]);
+    let (layout, rarity) = client.scan_nebula(&seed, &player);
+    assert_eq!(layout.width, GRID_SIZE);
+    assert_eq!(layout.height, GRID_SIZE);
+    assert_eq!(layout.cells.len(), TOTAL_CELLS);
+    assert!(
+        rarity == Rarity::Common
+            || rarity == Rarity::Uncommon
+            || rarity == Rarity::Rare
+            || rarity == Rarity::Epic
+            || rarity == Rarity::Legendary
+    );
+}
+
+#[test]
+fn test_scan_nebula_emits_event() {
+    let (env, client, player) = setup_env();
+    let seed = BytesN::from_array(&env, &[77u8; 32]);
+    let _result = client.scan_nebula(&seed, &player);
+
+    let events = env.events().all();
+    assert!(!events.is_empty(), "Expected NebulaScanned event to be emitted");
+
+    // Verify the last event has the correct topics
+    let last = events.get(events.len() - 1).unwrap();
+    let (_contract_addr, topics, _data) = last;
+    assert_eq!(topics.len(), 2);
+}
+
+#[test]
+fn test_scan_nebula_consistency_with_individual_calls() {
+    let (env, client, player) = setup_env();
+    let seed = BytesN::from_array(&env, &[33u8; 32]);
+
+    let layout = client.generate_nebula_layout(&seed, &player);
+    let rarity = client.calculate_rarity_tier(&layout);
+
+    let (scan_layout, scan_rarity) = client.scan_nebula(&seed, &player);
+
+    assert_eq!(layout.total_energy, scan_layout.total_energy);
+    assert_eq!(rarity, scan_rarity);
+}
 


### PR DESCRIPTION
## Summary

Implements the two core functions requested in #1:

- **`generate_nebula_layout(seed: BytesN<32>, player: Address) → NebulaLayout`** — Uses SHA-256 of `seed ‖ ledger_sequence ‖ timestamp` to seed a deterministic XorShift64 PRNG, producing a 16×16 procedural map of `NebulaCell` structs (cell type + energy). Player authorizes via `require_auth`.

- **`calculate_rarity_tier(layout: NebulaLayout) → Rarity`** — Scores the layout by counting rare cells (DarkMatter, ExoticMatter, Wormhole) and computing energy density. Returns one of five tiers: `Common`, `Uncommon`, `Rare`, `Epic`, `Legendary`. Fully on-chain, no off-chain RNG.

Additionally, `scan_nebula` is implemented as a convenience that calls both functions and emits a `NebulaScanned` event with the layout hash.

## What Changed

| File | Change |
|------|--------|
| `src/nebula_explorer.rs` | Types (`CellType`, `NebulaCell`, `NebulaLayout`, `Rarity`), XorShift64 PRNG, `generate_nebula_layout`, `calculate_rarity_tier`, `compute_layout_hash`, `emit_nebula_scanned` |
| `src/lib.rs` | Contract definition with three public functions: `generate_nebula_layout`, `calculate_rarity_tier`, `scan_nebula` |
| `src/resource_minter.rs` | Compilable `Resource` struct stub |
| `src/ship_registry.rs` | Compilable `Ship` struct stub |
| `tests/integration_tests.rs` | 18 tests covering layout dimensions, determinism, different seeds, ledger state, cell coordinates, timestamp, zero seed, all 5 rarity tiers, energy density contribution, end-to-end scan, event emission, and consistency |
| `examples/scan_example.rs` | Updated example documenting the generation flow, cell distribution, rarity scoring, and CLI usage |
| `README.md` | Architecture section updated with two Mermaid diagrams (generation flow + contract interaction) and revised data flow description |
| `Cargo.toml` | Fixed: removed non-existent `soroban-contract` dep, removed invalid `[[bin]]` section, added `rlib` crate-type for test linking, upgraded to soroban-sdk 22.0 |

## Acceptance Criteria Checklist

- [x] `generate_nebula_layout` fully implemented — ledger-seeded, deterministic 16×16 map
- [x] `calculate_rarity_tier` fully implemented — on-chain verifiable math, no off-chain RNG
- [x] Emits `NebulaScanned` event with layout hash
- [x] 18 unit/integration tests — covers all functions, all 5 rarity tiers, edge cases
- [x] Updated README Architecture section with Mermaid diagrams
- [x] Example in `/examples/` folder
- [x] `cargo test --all` passes
- [x] `cargo build --target wasm32-unknown-unknown --release` passes

Closes #1