### PR TITLE
feat: implement player profile and progress tracker

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Vec};
 
 mod nebula_explorer;
+mod player_profile;
 mod resource_minter;
 mod ship_registry;
 
@@ -10,6 +11,7 @@ pub use nebula_explorer::{
     calculate_rarity_tier, compute_layout_hash, generate_nebula_layout, CellType, NebulaCell,
     NebulaLayout, Rarity, GRID_SIZE, TOTAL_CELLS,
 };
+pub use player_profile::{PlayerProfile, ProfileError, ProgressUpdate};
 pub use resource_minter::Resource;
 pub use ship_registry::Ship;
 
@@ -53,6 +55,38 @@ impl NebulaNomadContract {
         nebula_explorer::emit_nebula_scanned(&env, &player, &layout_hash, &rarity);
 
         (layout, rarity)
+    }
+
+    // ─── Player Profile ───────────────────────────────────────────────────────
+
+    /// Create a new on-chain player profile. Returns the assigned profile ID.
+    pub fn initialize_profile(env: Env, owner: Address) -> Result<u64, ProfileError> {
+        player_profile::initialize_profile(&env, owner)
+    }
+
+    /// Update scan count and essence earned after a harvest. Owner-only.
+    pub fn update_progress(
+        env: Env,
+        caller: Address,
+        profile_id: u64,
+        scan_count: u32,
+        essence: i128,
+    ) -> Result<(), ProfileError> {
+        player_profile::update_progress(&env, caller, profile_id, scan_count, essence)
+    }
+
+    /// Apply up to 5 stat updates in a single transaction for multi-scan runs.
+    pub fn batch_update_progress(
+        env: Env,
+        caller: Address,
+        updates: Vec<ProgressUpdate>,
+    ) -> Result<(), ProfileError> {
+        player_profile::batch_update_progress(&env, caller, updates)
+    }
+
+    /// Retrieve a player profile by ID.
+    pub fn get_profile(env: Env, profile_id: u64) -> Result<PlayerProfile, ProfileError> {
+        player_profile::get_profile(&env, profile_id)
     }
 }
 

--- a/src/player_profile.rs
+++ b/src/player_profile.rs
@@ -1,0 +1,203 @@
+use soroban_sdk::{contracttype, contracterror, symbol_short, Address, Env, Vec};
+
+/// Maximum number of stat updates allowed in a single batch transaction.
+pub const MAX_BATCH_SIZE: u32 = 5;
+
+// ─── Storage Keys ─────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+#[contracttype]
+pub enum ProfileKey {
+    /// Individual profile data keyed by profile ID.
+    Profile(u64),
+    /// Maps an owner address to their profile ID (prevents duplicates).
+    OwnerProfile(Address),
+    /// Global auto-increment counter for profile IDs.
+    ProfileCount,
+}
+
+// ─── Data Types ───────────────────────────────────────────────────────────────
+
+/// On-chain player profile tracking nomad journey progress.
+#[derive(Clone)]
+#[contracttype]
+pub struct PlayerProfile {
+    pub id: u64,
+    pub owner: Address,
+    pub total_scans: u32,
+    pub essence_earned: i128,
+    /// ID of the first ship linked to this profile.
+    pub ship_id: u64,
+    /// Bitmask of unlocked achievement flags for future NFT badges.
+    pub achievement_flags: u32,
+    pub created_at: u64,
+    pub last_updated: u64,
+}
+
+/// Single entry for a batch progress update.
+#[derive(Clone)]
+#[contracttype]
+pub struct ProgressUpdate {
+    pub profile_id: u64,
+    pub scan_count: u32,
+    pub essence: i128,
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ProfileError {
+    ProfileNotFound = 1,
+    ProfileAlreadyExists = 2,
+    Unauthorized = 3,
+    BatchTooLarge = 4,
+}
+
+// ─── Functions ────────────────────────────────────────────────────────────────
+
+/// Create a new player profile for `owner`.
+///
+/// Derives a profile ID from the global counter. Emits `NomadJoined`.
+/// Returns the new profile ID.
+pub fn initialize_profile(env: &Env, owner: Address) -> Result<u64, ProfileError> {
+    owner.require_auth();
+
+    if env
+        .storage()
+        .persistent()
+        .has(&ProfileKey::OwnerProfile(owner.clone()))
+    {
+        return Err(ProfileError::ProfileAlreadyExists);
+    }
+
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&ProfileKey::ProfileCount)
+        .unwrap_or(0u64)
+        + 1;
+    env.storage().instance().set(&ProfileKey::ProfileCount, &id);
+
+    let timestamp = env.ledger().timestamp();
+    let profile = PlayerProfile {
+        id,
+        owner: owner.clone(),
+        total_scans: 0,
+        essence_earned: 0,
+        ship_id: id,
+        achievement_flags: 0,
+        created_at: timestamp,
+        last_updated: timestamp,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&ProfileKey::Profile(id), &profile);
+    env.storage()
+        .persistent()
+        .set(&ProfileKey::OwnerProfile(owner.clone()), &id);
+
+    env.events().publish(
+        (symbol_short!("nomad"), symbol_short!("joined")),
+        (owner, id),
+    );
+
+    Ok(id)
+}
+
+/// Atomically update scan stats and essence after a successful harvest.
+///
+/// Caller must be the profile owner. Emits `ProfileUpdated`.
+pub fn update_progress(
+    env: &Env,
+    caller: Address,
+    profile_id: u64,
+    scan_count: u32,
+    essence: i128,
+) -> Result<(), ProfileError> {
+    caller.require_auth();
+
+    let mut profile: PlayerProfile = env
+        .storage()
+        .persistent()
+        .get(&ProfileKey::Profile(profile_id))
+        .ok_or(ProfileError::ProfileNotFound)?;
+
+    if profile.owner != caller {
+        return Err(ProfileError::Unauthorized);
+    }
+
+    profile.total_scans += scan_count;
+    profile.essence_earned += essence;
+    profile.last_updated = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&ProfileKey::Profile(profile_id), &profile);
+
+    env.events().publish(
+        (symbol_short!("profile"), symbol_short!("updated")),
+        (caller, profile_id, profile.total_scans, profile.essence_earned),
+    );
+
+    Ok(())
+}
+
+/// Apply up to `MAX_BATCH_SIZE` stat updates in a single transaction.
+///
+/// Useful for multi-scan runs. Each update is validated for ownership.
+/// Emits `ProfileUpdated` for every entry in the batch.
+pub fn batch_update_progress(
+    env: &Env,
+    caller: Address,
+    updates: Vec<ProgressUpdate>,
+) -> Result<(), ProfileError> {
+    caller.require_auth();
+
+    if updates.len() > MAX_BATCH_SIZE {
+        return Err(ProfileError::BatchTooLarge);
+    }
+
+    for i in 0..updates.len() {
+        let update = updates.get(i).unwrap();
+
+        let mut profile: PlayerProfile = env
+            .storage()
+            .persistent()
+            .get(&ProfileKey::Profile(update.profile_id))
+            .ok_or(ProfileError::ProfileNotFound)?;
+
+        if profile.owner != caller {
+            return Err(ProfileError::Unauthorized);
+        }
+
+        profile.total_scans += update.scan_count;
+        profile.essence_earned += update.essence;
+        profile.last_updated = env.ledger().timestamp();
+
+        env.storage()
+            .persistent()
+            .set(&ProfileKey::Profile(update.profile_id), &profile);
+
+        env.events().publish(
+            (symbol_short!("profile"), symbol_short!("updated")),
+            (
+                caller.clone(),
+                update.profile_id,
+                profile.total_scans,
+                profile.essence_earned,
+            ),
+        );
+    }
+
+    Ok(())
+}
+
+/// Retrieve a player profile by ID. Returns `ProfileNotFound` if absent.
+pub fn get_profile(env: &Env, profile_id: u64) -> Result<PlayerProfile, ProfileError> {
+    env.storage()
+        .persistent()
+        .get(&ProfileKey::Profile(profile_id))
+        .ok_or(ProfileError::ProfileNotFound)
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3,8 +3,8 @@
 use soroban_sdk::testutils::{Address as _, Events, Ledger, LedgerInfo};
 use soroban_sdk::{vec, Address, BytesN, Env, IntoVal, Val, Vec};
 use stellar_nebula_nomad::{
-    CellType, NebulaNomadContract, NebulaNomadContractClient, NebulaCell, NebulaLayout, Rarity,
-    GRID_SIZE, TOTAL_CELLS,
+    CellType, NebulaNomadContract, NebulaNomadContractClient, NebulaCell, NebulaLayout,
+    ProfileError, ProgressUpdate, Rarity, GRID_SIZE, TOTAL_CELLS,
 };
 
 fn setup_env() -> (Env, NebulaNomadContractClient<'static>, Address) {
@@ -277,5 +277,111 @@ fn test_scan_nebula_consistency_with_individual_calls() {
 
     assert_eq!(layout.total_energy, scan_layout.total_energy);
     assert_eq!(rarity, scan_rarity);
+}
+
+// ─── player profile (issue #15) ───────────────────────────────────────────────
+
+#[test]
+fn test_initialize_profile_success() {
+    let (env, client, player) = setup_env();
+    let id = client.initialize_profile(&player);
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn test_initialize_profile_increments_id() {
+    let (env, client, _) = setup_env();
+    let player_a = Address::generate(&env);
+    let player_b = Address::generate(&env);
+    let id_a = client.initialize_profile(&player_a);
+    let id_b = client.initialize_profile(&player_b);
+    assert_eq!(id_a, 1);
+    assert_eq!(id_b, 2);
+}
+
+#[test]
+#[should_panic]
+fn test_initialize_profile_duplicate_panics() {
+    let (env, client, player) = setup_env();
+    client.initialize_profile(&player);
+    client.initialize_profile(&player);
+}
+
+#[test]
+fn test_get_profile_returns_correct_owner() {
+    let (env, client, player) = setup_env();
+    let id = client.initialize_profile(&player);
+    let profile = client.get_profile(&id);
+    assert_eq!(profile.owner, player);
+    assert_eq!(profile.total_scans, 0);
+    assert_eq!(profile.essence_earned, 0);
+}
+
+#[test]
+#[should_panic]
+fn test_get_profile_not_found_panics() {
+    let (_env, client, _) = setup_env();
+    client.get_profile(&999u64);
+}
+
+#[test]
+fn test_update_progress_accumulates_stats() {
+    let (env, client, player) = setup_env();
+    let id = client.initialize_profile(&player);
+    client.update_progress(&player, &id, &3u32, &500i128);
+    client.update_progress(&player, &id, &2u32, &250i128);
+    let profile = client.get_profile(&id);
+    assert_eq!(profile.total_scans, 5);
+    assert_eq!(profile.essence_earned, 750);
+}
+
+#[test]
+#[should_panic]
+fn test_update_progress_wrong_caller_panics() {
+    let (env, client, player) = setup_env();
+    let intruder = Address::generate(&env);
+    let id = client.initialize_profile(&player);
+    client.update_progress(&intruder, &id, &1u32, &100i128);
+}
+
+#[test]
+fn test_batch_update_progress_applies_all() {
+    let (env, client, player) = setup_env();
+    let id = client.initialize_profile(&player);
+    let updates = soroban_sdk::vec![
+        &env,
+        ProgressUpdate { profile_id: id, scan_count: 1, essence: 100 },
+        ProgressUpdate { profile_id: id, scan_count: 2, essence: 200 },
+        ProgressUpdate { profile_id: id, scan_count: 1, essence: 50  },
+    ];
+    client.batch_update_progress(&player, &updates);
+    let profile = client.get_profile(&id);
+    assert_eq!(profile.total_scans, 4);
+    assert_eq!(profile.essence_earned, 350);
+}
+
+#[test]
+#[should_panic]
+fn test_batch_update_exceeds_limit_panics() {
+    let (env, client, player) = setup_env();
+    let id = client.initialize_profile(&player);
+    let updates = soroban_sdk::vec![
+        &env,
+        ProgressUpdate { profile_id: id, scan_count: 1, essence: 10 },
+        ProgressUpdate { profile_id: id, scan_count: 1, essence: 10 },
+        ProgressUpdate { profile_id: id, scan_count: 1, essence: 10 },
+        ProgressUpdate { profile_id: id, scan_count: 1, essence: 10 },
+        ProgressUpdate { profile_id: id, scan_count: 1, essence: 10 },
+        ProgressUpdate { profile_id: id, scan_count: 1, essence: 10 },
+    ];
+    client.batch_update_progress(&player, &updates);
+}
+
+#[test]
+fn test_profile_emits_nomad_joined_event() {
+    let (env, client, player) = setup_env();
+    client.initialize_profile(&player);
+    let events = env.events().all();
+    assert!(!events.is_empty());
 }
 


### PR DESCRIPTION
## Summary

Implements `src/player_profile.rs` — the on-chain player identity layer for Nebula Nomad.

- **`initialize_profile(owner)`** — creates a profile with starting stats (scans, essence, ship link, achievement flags), keyed by a global auto-increment ID; prevents duplicate profiles via owner → ID binding; emits `NomadJoined`
- **`update_progress(caller, profile_id, scan_count, essence)`** — atomically updates stats after a harvest; owner-only via `require_auth` + ownership check; emits `ProfileUpdated`
- **`batch_update_progress(caller, updates)`** — up to 5 updates per tx for multi-scan runs; emits `ProfileUpdated` per entry
- **`get_profile(profile_id)`** — read-only lookup
- Custom error codes: `ProfileNotFound`, `ProfileAlreadyExists`, `Unauthorized`, `BatchTooLarge`
- 9 unit tests covering creation, duplicate rejection, progress accumulation, unauthorized access, batch limits, and event emission — all passing

Closes #15

## Related PRs (merge in order)
- **This PR** — #15 player profile ← merge first
- #16 session manager (branches from this)
- #17 blueprint factory (branches from #16)
- #19 referral system (branches from #17)