### PR TITLE
[DevOps] Add monitoring and alerting infrastructure

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,48 @@
+# Monitoring & Alerting
+
+## Overview
+
+The monitoring stack provides real-time visibility into contract health,
+performance, and errors using **Prometheus**, **Grafana**, and **Alertmanager**.
+
+## Quick Start
+
+```bash
+chmod +x setup-monitoring.sh
+./setup-monitoring.sh
+```
+
+Then open **http://localhost:3000** (Grafana) with the credentials from `monitoring/.env`.
+
+## Stack Components
+
+| Component      | Port | Purpose                          |
+|----------------|------|----------------------------------|
+| Prometheus     | 9090 | Metrics collection & storage     |
+| Grafana        | 3000 | Dashboards & visualisation       |
+| Alertmanager   | 9093 | Alert routing & notifications    |
+| Node Exporter  | 9100 | Host metrics (CPU, RAM, disk)    |
+
+## Alert Rules
+
+| Alert                    | Severity | Condition                          |
+|--------------------------|----------|------------------------------------|
+| HighContractErrorRate    | Critical | Error rate > 5% for 2min          |
+| HighGasUsage             | Warning  | p95 gas > 1M instructions          |
+| LowTransactionThroughput | Warning  | < 1 tx/min for 10min              |
+| SlowHorizonRpc           | Critical | p99 latency > 3s                  |
+| HighMemoryUsage          | Critical | Memory > 90% for 5min             |
+| HighDiskUsage            | Warning  | Disk > 85%                        |
+| MonitoringTargetDown     | Critical | Any scrape target unreachable      |
+
+## Data Retention
+
+Prometheus retains 90 days of metrics data by default.
+Adjust via `--storage.tsdb.retention.time` in `docker-compose.yml`.
+
+## Configuration
+
+Edit `monitoring/.env` to set:
+- `GRAFANA_PASSWORD` — Grafana admin password
+- `SLACK_WEBHOOK_URL` — Slack webhook for alerts
+- `HORIZON_HOST` — Stellar Horizon endpoint

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,48 @@
+global:
+  resolve_timeout: 5m
+  slack_api_url: '${SLACK_WEBHOOK_URL}'
+
+route:
+  group_by: ['alertname', 'severity']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: 'default'
+  routes:
+    - match:
+        severity: critical
+      receiver: 'critical-alerts'
+      repeat_interval: 1h
+    - match:
+        severity: warning
+      receiver: 'warning-alerts'
+      repeat_interval: 6h
+
+receivers:
+  - name: 'default'
+    slack_configs:
+      - channel: '#nebula-alerts'
+        title: '{{ .GroupLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.description }}{{ end }}'
+        send_resolved: true
+
+  - name: 'critical-alerts'
+    slack_configs:
+      - channel: '#nebula-critical'
+        title: '🚨 CRITICAL: {{ .GroupLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.description }}{{ end }}'
+        send_resolved: true
+
+  - name: 'warning-alerts'
+    slack_configs:
+      - channel: '#nebula-alerts'
+        title: '⚠️ WARNING: {{ .GroupLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.description }}{{ end }}'
+        send_resolved: true
+
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname']

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,85 @@
+# Monitoring stack for stellar-nebula-nomad
+# Usage: docker compose -f monitoring/docker-compose.yml up -d
+
+version: '3.8'
+
+volumes:
+  prometheus_data: {}
+  grafana_data: {}
+
+networks:
+  monitoring:
+    driver: bridge
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    container_name: nebula-prometheus
+    restart: unless-stopped
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alert-rules.yml:/etc/prometheus/alert-rules.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=90d'
+      - '--web.enable-lifecycle'
+      - '--web.enable-admin-api'
+    ports:
+      - '9090:9090'
+    networks:
+      - monitoring
+
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: nebula-alertmanager
+    restart: unless-stopped
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+    ports:
+      - '9093:9093'
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: nebula-grafana
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-changeme}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_ALERTING_ENABLED=true
+      - GF_UNIFIED_ALERTING_ENABLED=true
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/etc/grafana/dashboards:ro
+    ports:
+      - '3000:3000'
+    depends_on:
+      - prometheus
+    networks:
+      - monitoring
+
+  node-exporter:
+    image: prom/node-exporter:v1.8.0
+    container_name: nebula-node-exporter
+    restart: unless-stopped
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    ports:
+      - '9100:9100'
+    networks:
+      - monitoring

--- a/monitoring/grafana/dashboards/nebula-overview.json
+++ b/monitoring/grafana/dashboards/nebula-overview.json
@@ -1,0 +1,90 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": { "list": [] },
+  "description": "Stellar Nebula Nomad — contract health, performance, and error tracking",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 0.05 }] } },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "background" },
+      "title": "Contract Error Rate",
+      "type": "stat",
+      "targets": [{ "expr": "rate(nebula_contract_errors_total[5m]) / rate(nebula_contract_invocations_total[5m])", "legendFormat": "Error Rate", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "value" },
+      "title": "Transactions / min",
+      "type": "stat",
+      "targets": [{ "expr": "rate(nebula_contract_invocations_total[1m]) * 60", "legendFormat": "TX/min", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto", "colorMode": "value" },
+      "title": "p95 Gas (CPU Instructions)",
+      "type": "stat",
+      "targets": [{ "expr": "histogram_quantile(0.95, rate(nebula_contract_gas_instructions_bucket[10m]))", "legendFormat": "p95 Gas", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto", "colorMode": "background" },
+      "title": "Memory Usage",
+      "type": "stat",
+      "targets": [{ "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)", "legendFormat": "Memory", "refId": "A" }]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2 } }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 5,
+      "options": { "tooltip": { "mode": "multi" } },
+      "title": "Contract Invocations Over Time",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(nebula_contract_invocations_total[5m])", "legendFormat": "Invocations/s", "refId": "A" },
+        { "expr": "rate(nebula_contract_errors_total[5m])", "legendFormat": "Errors/s", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 6,
+      "title": "Horizon RPC Latency",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "histogram_quantile(0.50, rate(horizon_request_duration_seconds_bucket[5m]))", "legendFormat": "p50", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, rate(horizon_request_duration_seconds_bucket[5m]))", "legendFormat": "p95", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, rate(horizon_request_duration_seconds_bucket[5m]))", "legendFormat": "p99", "refId": "C" }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["stellar", "soroban", "nebula"],
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "title": "Stellar Nebula Nomad — Overview",
+  "uid": "nebula-overview-v1",
+  "version": 1
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'stellar-nebula-nomad'
+    orgId: 1
+    folder: 'Stellar Nebula Nomad'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: '15s'
+      queryTimeout: '60s'
+      httpMethod: POST

--- a/monitoring/prometheus/alert-rules.yml
+++ b/monitoring/prometheus/alert-rules.yml
@@ -1,0 +1,93 @@
+groups:
+  - name: stellar-nebula-nomad-critical
+    interval: 30s
+    rules:
+
+      # Contract invocation error rate > 5%
+      - alert: HighContractErrorRate
+        expr: |
+          (
+            rate(nebula_contract_errors_total[5m])
+            /
+            rate(nebula_contract_invocations_total[5m])
+          ) > 0.05
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High contract error rate ({{ $value | humanizePercentage }})"
+          description: "Contract error rate has exceeded 5% for more than 2 minutes."
+
+      # Gas usage per transaction > 1M instructions
+      - alert: HighGasUsage
+        expr: |
+          histogram_quantile(0.95,
+            rate(nebula_contract_gas_instructions_bucket[10m])
+          ) > 1000000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High gas usage detected (p95 > 1M instructions)"
+          description: "95th percentile gas usage has exceeded 1,000,000 CPU instructions."
+
+      # Transaction throughput drops below 1 tx/min
+      - alert: LowTransactionThroughput
+        expr: |
+          rate(nebula_contract_invocations_total[5m]) < 0.016
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Low transaction throughput"
+          description: "Transaction throughput has dropped below 1 per minute for 10 minutes."
+
+      # Horizon RPC latency p99 > 3s
+      - alert: SlowHorizonRpc
+        expr: |
+          histogram_quantile(0.99,
+            rate(horizon_request_duration_seconds_bucket[5m])
+          ) > 3
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Slow Horizon RPC responses (p99 > 3s)"
+          description: "Horizon RPC 99th percentile latency has exceeded 3 seconds."
+
+      # Node memory > 90%
+      - alert: HighMemoryUsage
+        expr: |
+          (
+            1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)
+          ) > 0.90
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High memory usage ({{ $value | humanizePercentage }})"
+          description: "Host memory usage has exceeded 90% for 5 minutes."
+
+      # Node disk > 85%
+      - alert: HighDiskUsage
+        expr: |
+          (
+            1 - (node_filesystem_avail_bytes{fstype!="tmpfs"} /
+                 node_filesystem_size_bytes{fstype!="tmpfs"})
+          ) > 0.85
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High disk usage ({{ $value | humanizePercentage }})"
+          description: "Disk usage has exceeded 85% on {{ $labels.mountpoint }}."
+
+      # Prometheus target down
+      - alert: MonitoringTargetDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Monitoring target down: {{ $labels.job }}"
+          description: "Scrape target {{ $labels.instance }} ({{ $labels.job }}) is unreachable."

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,51 @@
+# Prometheus configuration for stellar-nebula-nomad
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    monitor: 'stellar-nebula-nomad'
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
+# Load alert rules
+rule_files:
+  - 'alert-rules.yml'
+
+# Scrape configurations
+scrape_configs:
+  # Prometheus self-monitoring
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # Node exporter — host metrics (CPU, memory, disk, network)
+  - job_name: 'node-exporter'
+    static_configs:
+      - targets: ['node-exporter:9100']
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+
+  # Stellar Horizon RPC metrics
+  - job_name: 'stellar-horizon'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['${HORIZON_HOST:-horizon:8000}']
+    relabel_configs:
+      - target_label: service
+        replacement: 'stellar-horizon'
+
+  # Contract performance metrics (custom exporter)
+  - job_name: 'nebula-contract'
+    metrics_path: '/metrics'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['contract-exporter:9200']
+    relabel_configs:
+      - target_label: service
+        replacement: 'nebula-contract'

--- a/setup-monitoring.sh
+++ b/setup-monitoring.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# setup-monitoring.sh — Bootstrap the stellar-nebula-nomad monitoring stack
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MONITORING_DIR="$SCRIPT_DIR/monitoring"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+err()  { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# Check prerequisites
+check_prerequisites() {
+  log "Checking prerequisites..."
+  for cmd in docker curl; do
+    if ! command -v "$cmd" &>/dev/null; then
+      err "'$cmd' is required but not installed."
+      exit 1
+    fi
+  done
+
+  if ! docker compose version &>/dev/null && ! docker-compose version &>/dev/null; then
+    err "Docker Compose is required but not installed."
+    exit 1
+  fi
+  log "Prerequisites OK."
+}
+
+# Create .env if it doesn't exist
+setup_env() {
+  local env_file="$MONITORING_DIR/.env"
+  if [[ ! -f "$env_file" ]]; then
+    warn ".env not found — creating from defaults."
+    cat > "$env_file" <<EOF
+GRAFANA_USER=admin
+GRAFANA_PASSWORD=changeme_in_production
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK
+HORIZON_HOST=horizon:8000
+EOF
+    warn "Edit $env_file before deploying to production!"
+  else
+    log ".env already exists — skipping."
+  fi
+}
+
+# Start the monitoring stack
+start_stack() {
+  log "Starting monitoring stack..."
+  docker compose -f "$MONITORING_DIR/docker-compose.yml" up -d
+  log "Stack started."
+}
+
+# Wait for Grafana to become healthy
+wait_for_grafana() {
+  log "Waiting for Grafana to be ready..."
+  local retries=30
+  while ! curl -sf http://localhost:3000/api/health &>/dev/null; do
+    retries=$((retries - 1))
+    if [[ $retries -eq 0 ]]; then
+      err "Grafana did not become ready in time."
+      exit 1
+    fi
+    sleep 2
+  done
+  log "Grafana is ready."
+}
+
+# Print access info
+print_info() {
+  echo ""
+  log "Monitoring stack is running!"
+  echo ""
+  echo "  Grafana:      http://localhost:3000  (admin / see .env)"
+  echo "  Prometheus:   http://localhost:9090"
+  echo "  Alertmanager: http://localhost:9093"
+  echo ""
+  warn "Remember to set GRAFANA_PASSWORD and SLACK_WEBHOOK_URL in monitoring/.env"
+}
+
+main() {
+  check_prerequisites
+  setup_env
+  start_stack
+  wait_for_grafana
+  print_info
+}
+
+main "$@"


### PR DESCRIPTION
Closes #117 

## What this PR does
- Added `monitoring/` directory with full Prometheus + Grafana + Alertmanager stack
- `monitoring/prometheus/prometheus.yml` — scrape config for Prometheus, Node Exporter, Horizon RPC, and contract metrics
- `monitoring/prometheus/alert-rules.yml` — 7 alert rules covering error rate, gas usage, throughput, RPC latency, memory, disk, and target availability
- `monitoring/alertmanager/alertmanager.yml` — Slack routing for critical and warning alerts
- `monitoring/grafana/` — provisioned datasource, dashboard provider, and overview dashboard
- `monitoring/docker-compose.yml` — one-command stack startup with 90-day data retention
- `setup-monitoring.sh` — automated bootstrap script with prerequisite checks
- `docs/monitoring.md` — full documentation

## How to run
```bash
chmod +x setup-monitoring.sh
./setup-monitoring.sh
```