### PR TITLE
Implement ship NFT transfer between players

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1044,6 +1044,23 @@ impl NebulaNomadContract {
         result
     }
 
+    /// Transfer a ship NFT from `from` to `to`.
+    pub fn transfer_ship(
+        env: Env,
+        ship_id: u64,
+        from: Address,
+        to: Address,
+    ) -> Result<ShipNft, ShipError> {
+        let result = ship_nft::transfer_ship(&env, ship_id, &from, &to);
+        if result.is_ok() {
+            let mut b = [0u8; 128];
+            b[0..8].copy_from_slice(&ship_id.to_be_bytes());
+            let details = BytesN::from_array(&env, &b);
+            let _ = audit_logger::log_audit_event(&env, Some(&from), symbol_short!("ts"), details);
+        }
+        result
+    }
+
     /// Read a ship by ID.
     pub fn get_ship(env: Env, ship_id: u64) -> Result<ShipNft, ShipError> {
         ship_nft::get_ship(&env, ship_id)

--- a/src/ship_nft.rs
+++ b/src/ship_nft.rs
@@ -157,9 +157,9 @@ pub fn emit_ship_minted(env: &Env, ship: &ShipNft) {
     );
 }
 
-pub fn emit_ownership_transferred(env: &Env, ship_id: u64, from: &Address, to: &Address) {
+pub fn emit_ship_transferred(env: &Env, ship_id: u64, from: &Address, to: &Address) {
     env.events().publish(
-        (symbol_short!("ship"), symbol_short!("xfer")),
+        (symbol_short!("ship"), symbol_short!("transfer")),
         (ship_id, from.clone(), to.clone()),
     );
 }
@@ -256,6 +256,8 @@ pub fn batch_mint_ships(
             ship_type: st.clone(),
             hull,
             scanner_power,
+            durability: 100,
+            max_durability: 100,
             metadata: metadata.clone(),
         };
 
@@ -269,15 +271,16 @@ pub fn batch_mint_ships(
     Ok(ships)
 }
 
-/// Transfer ownership of a Ship NFT.
+/// Transfer ownership of a Ship NFT from one player to another.
 ///
-/// The current `owner` must authorize. The new owner's address is
-/// validated (must differ from current owner). Emits an
-/// `OwnershipTransferred` event.
-pub fn transfer_ownership(
+/// The `from` address must authorize the transfer and must be the current
+/// owner. The recipient must differ from the current owner. Ownership indices
+/// are updated atomically and a `ShipTransferred` event is emitted.
+pub fn transfer_ship(
     env: &Env,
     ship_id: u64,
-    new_owner: &Address,
+    from: &Address,
+    to: &Address,
 ) -> Result<ShipNft, ShipError> {
     enter_lock(env)?;
 
@@ -292,28 +295,39 @@ pub fn transfer_ownership(
             e
         })?;
 
-    // Only the current owner can initiate a transfer.
-    ship.owner.require_auth();
+    from.require_auth();
 
-    if ship.owner == *new_owner {
+    if ship.owner != *from {
+        exit_lock(env);
+        return Err(ShipError::NotOwner);
+    }
+
+    if ship.owner == *to {
         exit_lock(env);
         return Err(ShipError::SameOwner);
     }
 
-    let old_owner = ship.owner.clone();
+    remove_ship_from_owner(env, from, ship_id);
+    add_ship_to_owner(env, to, ship_id);
 
-    // Update ownership indices.
-    remove_ship_from_owner(env, &old_owner, ship_id);
-    add_ship_to_owner(env, new_owner, ship_id);
-
-    ship.owner = new_owner.clone();
+    ship.owner = to.clone();
     store_ship(env, &ship);
 
-    emit_ownership_transferred(env, ship_id, &old_owner, new_owner);
+    emit_ship_transferred(env, ship_id, from, to);
 
     exit_lock(env);
 
     Ok(ship)
+}
+
+/// Backwards-compatible alias for older callers.
+pub fn transfer_ownership(
+    env: &Env,
+    ship_id: u64,
+    new_owner: &Address,
+) -> Result<ShipNft, ShipError> {
+    let ship = get_ship(env, ship_id)?;
+    transfer_ship(env, ship_id, &ship.owner, new_owner)
 }
 
 /// Read a ship by ID (view function — no auth required).

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use soroban_sdk::testutils::{Address as _, Events, Ledger, LedgerInfo};
-use soroban_sdk::{symbol_short, vec, Address, Bytes, BytesN, Env, String, Vec};
+use soroban_sdk::{symbol_short, vec, Address, Bytes, BytesN, Env, IntoVal, String, Vec};
 use stellar_nebula_nomad::{
     Blueprint, BlueprintError, BlueprintRarity, CellType, NebulaCell, NebulaLayout,
     NebulaNomadContract, NebulaNomadContractClient, ProfileError, ProgressUpdate, Rarity,
@@ -477,6 +477,56 @@ fn test_mint_ship_and_transfer_ownership() {
     let new_owner = Address::generate(&env);
     let transferred = client.transfer_ownership(&ship.id, &new_owner);
     assert_eq!(transferred.owner, new_owner);
+}
+
+#[test]
+fn test_transfer_ship_updates_ownership_tracking_and_emits_event() {
+    let (env, client, player) = setup_env();
+    let metadata = Bytes::from_slice(&env, &[0u8; 4]);
+    let ship = client.mint_ship(&player, &symbol_short!("fighter"), &metadata);
+    let new_owner = Address::generate(&env);
+
+    let transferred = client.transfer_ship(&ship.id, &player, &new_owner);
+
+    assert_eq!(transferred.owner, new_owner);
+    assert_eq!(client.get_ship(&ship.id).owner, new_owner);
+    assert_eq!(client.get_ships_by_owner(&player).len(), 0);
+    let new_owner_ships = client.get_ships_by_owner(&new_owner);
+    assert_eq!(new_owner_ships.len(), 1);
+    assert_eq!(new_owner_ships.get(0).unwrap(), ship.id);
+
+    let events = env.events().all();
+    let (_, topics, _) = events.get(events.len() - 2).unwrap();
+    assert_eq!(topics.get(0).unwrap(), symbol_short!("ship").into_val(&env));
+    assert_eq!(topics.get(1).unwrap(), symbol_short!("transfer").into_val(&env));
+}
+
+#[test]
+fn test_transfer_ship_rejects_non_owner_sender() {
+    let (env, client, player) = setup_env();
+    let metadata = Bytes::from_slice(&env, &[0u8; 4]);
+    let ship = client.mint_ship(&player, &symbol_short!("explorer"), &metadata);
+    let not_owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+
+    let result = client.try_transfer_ship(&ship.id, &not_owner, &new_owner);
+
+    assert_eq!(result, Err(Ok(ShipError::NotOwner)));
+    assert_eq!(client.get_ship(&ship.id).owner, player);
+}
+
+#[test]
+fn test_transfer_ship_rejects_same_owner_and_missing_ship() {
+    let (env, client, player) = setup_env();
+    let metadata = Bytes::from_slice(&env, &[0u8; 4]);
+    let ship = client.mint_ship(&player, &symbol_short!("hauler"), &metadata);
+    let new_owner = Address::generate(&env);
+
+    let same_owner = client.try_transfer_ship(&ship.id, &player, &player);
+    assert_eq!(same_owner, Err(Ok(ShipError::SameOwner)));
+
+    let missing = client.try_transfer_ship(&999_999, &player, &new_owner);
+    assert_eq!(missing, Err(Ok(ShipError::ShipNotFound)));
 }
 
 #[test]


### PR DESCRIPTION
closes #178 

## Summary

Added explicit `transfer_ship` support to enable secure NFT transfers between players. The implementation enforces authorization and ownership validation, updates ownership indexes, emits a transfer event for indexers, and records an audit log. Batch minting was also updated to initialize durability consistently with single-ship minting while preserving backwards compatibility through the existing `transfer_ownership` API.

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation

## Test plan

* [ ] `pnpm typecheck`
* [ ] `pnpm test`
* [x] Manual testing (describe):

  * Ran `git diff --check` and `cargo fmt` successfully.
  * Attempted `cargo test test_transfer_ship -- --nocapture`; execution was blocked by unrelated, pre-existing repository compile errors. Added integration tests are ready to run once those issues are resolved.

## Checklist

* [x] Follows project code conventions
* [x] TODOs reference issues where applicable
* [x] No secrets or credentials committed
