### PR TITLE
fix(security): overflow checks, reentrancy guards, admin hardening, c…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,10 @@ panic = "abort"
 incremental = false
 # Strip debug symbols and DWARF sections from the final artifact.
 strip = true
-# Compact general allocator to reduce binary overhead.
-overflow-checks = false
+# Arithmetic overflow must abort (not silently wrap) — see docs/YIELD_MATH.md
+# and the checked/saturating arithmetic used throughout the balance-modifying
+# contract functions (Issue #239).
+overflow-checks = true
 
 # ─── Profile for post-build wasm-opt processing ───────────────────────────
 # When `wasm-opt -Oz` is run downstream (e.g. in deploy.sh), this profile

--- a/docs/RBAC_PATTERN_GUIDE.md
+++ b/docs/RBAC_PATTERN_GUIDE.md
@@ -206,6 +206,33 @@ Result: Frontend can disable buttons or show warnings for actions the user can't
 
 ---
 
+## Hardening Ad-Hoc Admin Setters (Issue #237)
+
+Some modules (`leaderboards`, `content_tools`, `pvp_combat`) predate the RBAC
+system above and use a simpler single-admin pattern instead of
+`access_control`. Their `set_admin(env, admin)` functions used to only
+require the *incoming* admin's own signature — never the *current* admin's —
+which let any caller call `set_admin` at any time and silently hijack the
+role.
+
+They are now one-time initializers, matching the idempotency guard already
+used by `access_control::init_roles` and `emergency_controls::initialize_admins`:
+
+```rust
+pub fn set_admin(env: &Env, admin: &Address) -> Result<(), MyError> {
+    admin.require_auth();
+    if get_admin(env).is_some() {
+        return Err(MyError::AlreadyInitialized);
+    }
+    env.storage().persistent().set(&DataKey::Admin, admin);
+    Ok(())
+}
+```
+
+Once set, admin can only change via an explicit transfer function gated on
+the *current* admin's signature (see `access_control::transfer_admin` for the
+reference implementation) — never via a bare re-call of `set_admin`.
+
 ## Common Mistakes to Avoid
 
 ### ❌ Mistake 1: Forgetting to Initialize

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -75,8 +75,11 @@ pub fn record_scan(env: &Env, player: &Address, essence: u64) {
         .persistent()
         .get(&AnalyticsDataKey::GlobalStats)
         .unwrap_or_default();
-    stats.total_scans += 1;
-    stats.total_essence_accrued += essence;
+    // Non-critical, display-only counters: clamp on overflow rather than
+    // panicking so a dashboard aggregate can never brick scan recording
+    // (Issue #239 — saturating arithmetic for non-financial accumulators).
+    stats.total_scans = stats.total_scans.saturating_add(1);
+    stats.total_essence_accrued = stats.total_essence_accrued.saturating_add(essence);
     env.storage()
         .persistent()
         .set(&AnalyticsDataKey::GlobalStats, &stats);
@@ -87,9 +90,10 @@ pub fn record_scan(env: &Env, player: &Address, essence: u64) {
         .persistent()
         .get(&AnalyticsDataKey::PlayerEssence(player.clone()))
         .unwrap_or(0);
-    env.storage()
-        .persistent()
-        .set(&AnalyticsDataKey::PlayerEssence(player.clone()), &(prev + essence));
+    env.storage().persistent().set(
+        &AnalyticsDataKey::PlayerEssence(player.clone()),
+        &prev.saturating_add(essence),
+    );
 
     // Ensure the player appears in the leaderboard candidate list.
     register_player(env, player);
@@ -104,7 +108,7 @@ pub fn record_ship_minted(env: &Env) {
         .persistent()
         .get(&AnalyticsDataKey::GlobalStats)
         .unwrap_or_default();
-    stats.ships_minted += 1;
+    stats.ships_minted = stats.ships_minted.saturating_add(1);
     env.storage()
         .persistent()
         .set(&AnalyticsDataKey::GlobalStats, &stats);
@@ -322,6 +326,30 @@ mod tests {
         let env = Env::default();
         let id = env.register_contract(None, Stub);
         (env, id)
+    }
+
+    #[test]
+    fn test_record_scan_clamps_instead_of_panicking_at_max() {
+        let (env, contract_id) = make_env();
+        let player = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            env.storage().persistent().set(
+                &AnalyticsDataKey::GlobalStats,
+                &GlobalStats {
+                    total_scans: u64::MAX,
+                    ships_minted: 0,
+                    total_essence_accrued: u64::MAX,
+                },
+            );
+
+            // Must not panic even though the accumulators are already at u64::MAX.
+            record_scan(&env, &player, 100);
+
+            let stats = get_global_stats(&env);
+            assert_eq!(stats.total_scans, u64::MAX);
+            assert_eq!(stats.total_essence_accrued, u64::MAX);
+        });
     }
 
     #[test]

--- a/src/content_tools.rs
+++ b/src/content_tools.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, String, Vec, Symbol, Map, Bytes};
+use soroban_sdk::{
+    contracterror, contracttype, symbol_short, Address, Bytes, Env, Map, String, Symbol, Vec,
+};
 
 // ── Error ─────────────────────────────────────────────────────────────────────
 
@@ -24,6 +26,8 @@ pub enum ContentToolsError {
     UnderReview = 8,
     /// Content has been rejected.
     ContentRejected = 9,
+    /// Admin has already been set; set_admin is a one-time initializer (Issue #237).
+    AlreadyInitialized = 10,
 }
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
@@ -128,22 +132,27 @@ pub const CONTENT_TYPE_EVENT: &str = "event";
 
 // ── Admin Functions ──────────────────────────────────────────────────────────
 
-pub fn set_admin(env: &Env, admin: &Address) {
+/// Bootstrap the content-tools admin. Callable exactly once — subsequent
+/// calls return `AlreadyInitialized` instead of letting any caller
+/// overwrite the admin (Issue #237: this previously let anyone re-appoint
+/// themselves).
+pub fn set_admin(env: &Env, admin: &Address) -> Result<(), ContentToolsError> {
     admin.require_auth();
-    let old_admin = get_admin(env);
+    if get_admin(env).is_some() {
+        return Err(ContentToolsError::AlreadyInitialized);
+    }
     env.storage()
         .persistent()
         .set(&ContentDataKey::Admin, admin);
     env.events().publish(
         (symbol_short!("ct"), symbol_short!("cnt_admn")),
-        (old_admin, admin.clone()),
+        (Option::<Address>::None, admin.clone()),
     );
+    Ok(())
 }
 
 fn get_admin(env: &Env) -> Option<Address> {
-    env.storage()
-        .persistent()
-        .get(&ContentDataKey::Admin)
+    env.storage().persistent().get(&ContentDataKey::Admin)
 }
 
 fn require_admin(env: &Env, caller: &Address) -> Result<(), ContentToolsError> {
@@ -220,12 +229,15 @@ pub fn create_content(
         .set(&ContentDataKey::Content(content_id), &content);
 
     creator_contents.push_back(content_id);
-    env.storage().persistent().set(&creator_key, &creator_contents);
-
-    // Set initial status as pending review
     env.storage()
         .persistent()
-        .set(&ContentDataKey::Status(content_id), &symbol_short!("pending"));
+        .set(&creator_key, &creator_contents);
+
+    // Set initial status as pending review
+    env.storage().persistent().set(
+        &ContentDataKey::Status(content_id),
+        &symbol_short!("pending"),
+    );
 
     env.events().publish(
         (symbol_short!("ct"), symbol_short!("created")),
@@ -436,22 +448,14 @@ pub fn vote_content(
 
     // Update vote count
     let vote_count_key = ContentDataKey::VoteCount(content_id);
-    let vote_count: u64 = env
-        .storage()
-        .persistent()
-        .get(&vote_count_key)
-        .unwrap_or(0);
+    let vote_count: u64 = env.storage().persistent().get(&vote_count_key).unwrap_or(0);
     env.storage()
         .persistent()
         .set(&vote_count_key, &(vote_count + 1));
 
     // Update rating sum
     let rating_sum_key = ContentDataKey::RatingSum(content_id);
-    let rating_sum: u64 = env
-        .storage()
-        .persistent()
-        .get(&rating_sum_key)
-        .unwrap_or(0);
+    let rating_sum: u64 = env.storage().persistent().get(&rating_sum_key).unwrap_or(0);
     env.storage()
         .persistent()
         .set(&rating_sum_key, &(rating_sum + rating as u64));
@@ -524,10 +528,7 @@ pub fn get_vote_result(env: &Env, content_id: u64) -> VoteResult {
 
 // ── Play Count ─────────────────────────────────────────────────────────────
 
-pub fn increment_play_count(
-    env: &Env,
-    content_id: u64,
-) -> Result<(), ContentToolsError> {
+pub fn increment_play_count(env: &Env, content_id: u64) -> Result<(), ContentToolsError> {
     let key = ContentDataKey::Content(content_id);
     let mut content: CreatedContent = env
         .storage()
@@ -753,7 +754,11 @@ pub fn purchase_content(
 
     // Credit creator revenue
     let creator_rev_key = ContentDataKey::CreatorRevenue(content.creator.clone());
-    let creator_balance: i128 = env.storage().persistent().get(&creator_rev_key).unwrap_or(0);
+    let creator_balance: i128 = env
+        .storage()
+        .persistent()
+        .get(&creator_rev_key)
+        .unwrap_or(0);
     env.storage()
         .persistent()
         .set(&creator_rev_key, &(creator_balance + creator_share));
@@ -764,9 +769,10 @@ pub fn purchase_content(
         .persistent()
         .get(&ContentDataKey::PlatformRevenue)
         .unwrap_or(0);
-    env.storage()
-        .persistent()
-        .set(&ContentDataKey::PlatformRevenue, &(platform_balance + platform_share));
+    env.storage().persistent().set(
+        &ContentDataKey::PlatformRevenue,
+        &(platform_balance + platform_share),
+    );
 
     let content_price = content.price;
 
@@ -785,7 +791,13 @@ pub fn purchase_content(
 
     env.events().publish(
         (symbol_short!("ct"), symbol_short!("purchased")),
-        (content_id, buyer.clone(), content_price, creator_share, platform_share),
+        (
+            content_id,
+            buyer.clone(),
+            content_price,
+            creator_share,
+            platform_share,
+        ),
     );
 
     Ok(result)
@@ -903,12 +915,31 @@ mod tests {
             .unwrap();
 
             // Need admin to approve first
-            set_admin(&env, &creator);
+            set_admin(&env, &creator).unwrap();
             approve_content(&env, &creator, content_id).unwrap();
 
             vote_content(&env, &voter, content_id, 5).unwrap();
             let result = get_vote_result(&env, content_id);
             assert_eq!(result.total_votes, 1);
+        });
+    }
+
+    #[test]
+    fn test_set_admin_cannot_be_hijacked_after_init() {
+        // Issue #237: set_admin previously let ANY caller overwrite the
+        // admin at any time. Now it is a one-time initializer.
+        let (env, _contract_id) = make_env();
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        env.as_contract(&_contract_id, || {
+            set_admin(&env, &admin).unwrap();
+
+            let result = set_admin(&env, &attacker);
+            assert_eq!(result, Err(ContentToolsError::AlreadyInitialized));
+
+            let result = approve_content(&env, &attacker, 1);
+            assert_eq!(result, Err(ContentToolsError::Unauthorized));
         });
     }
 }

--- a/src/crafting.rs
+++ b/src/crafting.rs
@@ -1,5 +1,7 @@
+use crate::recipes::{
+    get_recipe, get_recipe_specialization, is_rare, is_unlocked, unlock_rare_recipe, Specialization,
+};
 use soroban_sdk::{contracterror, symbol_short, Address, Env, Symbol, Vec};
-use crate::recipes::{get_recipe, is_rare, is_unlocked, unlock_rare_recipe};
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -9,13 +11,59 @@ pub enum CraftingError {
     InsufficientLevel = 2,
     InsufficientResources = 3,
     RecipeNotFound = 4,
+    /// Player already chose a specialization; it cannot be changed (Issue #266).
+    SpecializationAlreadyChosen = 5,
+    /// The recipe requires a specialization the player has not chosen.
+    WrongSpecialization = 6,
+    /// The requested skill node does not exist.
+    NodeNotFound = 7,
+    /// The skill node was already unlocked.
+    NodeAlreadyUnlocked = 8,
+    /// Not enough skill points to unlock this node.
+    InsufficientSkillPoints = 9,
 }
 
 #[soroban_sdk::contracttype]
 pub enum CraftingDataKey {
     PlayerLevel(Address),
     PlayerXP(Address),
+    /// Player's chosen crafting specialization, if any (Issue #266).
+    PlayerSpecialization(Address),
+    /// Unspent skill points, earned on level-up.
+    SkillPoints(Address),
+    /// Whether (player, node_id) has been unlocked.
+    UnlockedNode(Address, u32),
+    /// Number of times (player, recipe_id) has been successfully crafted —
+    /// drives the mastery output bonus.
+    MasteryCount(Address, u32),
 }
+
+// ── Skill Tree (Issue #266) ─────────────────────────────────────────────────
+//
+// A small, fixed skill tree per specialization: (node_id, specialization, cost).
+// The first node in each branch ("keen eye") boosts rare-recipe discovery odds.
+
+/// (node_id, specialization, skill point cost).
+const SKILL_TREE: &[(u32, Specialization, u32)] = &[
+    (1, Specialization::Metallurgy, 1),
+    (2, Specialization::Metallurgy, 2),
+    (3, Specialization::Alchemy, 1),
+    (4, Specialization::Alchemy, 2),
+    (5, Specialization::Engineering, 1),
+    (6, Specialization::Engineering, 2),
+];
+
+/// Nodes that boost rare-recipe discovery odds when unlocked (the "keen eye"
+/// node in each branch).
+const DISCOVERY_NODES: &[u32] = &[1, 3, 5];
+
+/// Crafts of the same recipe between each +1 mastery output bonus.
+const MASTERY_INTERVAL: u32 = 10;
+
+/// Base rare-recipe discovery chance out of 100.
+const BASE_DISCOVERY_PCT: u64 = 5;
+/// Boosted discovery chance (with a "keen eye" node unlocked) out of 100.
+const BOOSTED_DISCOVERY_PCT: u64 = 10;
 
 pub fn craft(env: Env, player: Address, recipe_id: u32) -> Result<(), CraftingError> {
     player.require_auth();
@@ -23,6 +71,14 @@ pub fn craft(env: Env, player: Address, recipe_id: u32) -> Result<(), CraftingEr
 
     if is_rare(&recipe) && !is_unlocked(&env, &player, recipe_id) {
         return Err(CraftingError::RecipeLocked);
+    }
+
+    // Specialization gate: recipes tagged via set_recipe_specialization
+    // require the player to have chosen the matching tree (Issue #266).
+    if let Some(required_spec) = get_recipe_specialization(&env, recipe_id) {
+        if get_specialization(&env, &player) != Some(required_spec) {
+            return Err(CraftingError::WrongSpecialization);
+        }
     }
 
     let level = get_level(&env, player.clone());
@@ -33,13 +89,29 @@ pub fn craft(env: Env, player: Address, recipe_id: u32) -> Result<(), CraftingEr
     require_resources(&env, &player, &recipe.inputs)?;
     consume_resources(&env, &player, &recipe.inputs);
 
-    mint_resource(&env, &player, recipe.output);
+    // Mastery bonus: every MASTERY_INTERVAL crafts of the same recipe grants
+    // +1 extra output (Issue #266).
+    let mastery_count = record_craft(&env, &player, recipe_id);
+    let bonus_output = mastery_count / MASTERY_INTERVAL;
+    let (output_symbol, base_amount) = recipe.output.clone();
+    mint_resource(
+        &env,
+        &player,
+        (output_symbol, base_amount.saturating_add(bonus_output)),
+    );
 
     let xp_gain = 10 + (recipe.rarity * 5);
     add_xp(&env, player.clone(), xp_gain);
 
+    // Recipe discovery: base 5% chance, boosted to 10% with a "keen eye"
+    // skill node unlocked (Issue #266).
+    let discovery_pct = if has_discovery_boost(&env, &player) {
+        BOOSTED_DISCOVERY_PCT
+    } else {
+        BASE_DISCOVERY_PCT
+    };
     let random: u64 = env.prng().gen();
-    if random % 100 < 5 {
+    if random % 100 < discovery_pct {
         unlock_rare_recipe(&env, player.clone(), 999);
         env.events().publish(
             (symbol_short!("rare_dis"), player.clone()),
@@ -57,15 +129,132 @@ pub fn add_xp(env: &Env, player: Address, xp: u32) {
     let old_level = get_level(env, player.clone());
     let new_level = 1 + (new_xp / 100);
 
-    env.storage().persistent().set(&CraftingDataKey::PlayerXP(player.clone()), &new_xp);
+    env.storage()
+        .persistent()
+        .set(&CraftingDataKey::PlayerXP(player.clone()), &new_xp);
 
     if new_level > old_level {
-        env.storage().persistent().set(&CraftingDataKey::PlayerLevel(player.clone()), &new_level);
-        env.events().publish(
-            (symbol_short!("levelup"), player),
-            new_level,
-        );
+        env.storage()
+            .persistent()
+            .set(&CraftingDataKey::PlayerLevel(player.clone()), &new_level);
+
+        // Award 1 skill point per level gained (Issue #266).
+        let levels_gained = new_level - old_level;
+        let points = get_skill_points(env, player.clone()).saturating_add(levels_gained);
+        env.storage()
+            .persistent()
+            .set(&CraftingDataKey::SkillPoints(player.clone()), &points);
+
+        env.events()
+            .publish((symbol_short!("levelup"), player), new_level);
     }
+}
+
+// ── Skill Tree API (Issue #266) ─────────────────────────────────────────────
+
+pub fn get_skill_points(env: &Env, player: Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&CraftingDataKey::SkillPoints(player))
+        .unwrap_or(0)
+}
+
+pub fn get_specialization(env: &Env, player: &Address) -> Option<Specialization> {
+    env.storage()
+        .persistent()
+        .get(&CraftingDataKey::PlayerSpecialization(player.clone()))
+}
+
+/// Choose a crafting specialization. One-time — cannot be changed afterward.
+pub fn choose_specialization(
+    env: &Env,
+    player: Address,
+    specialization: Specialization,
+) -> Result<(), CraftingError> {
+    player.require_auth();
+
+    if get_specialization(env, &player).is_some() {
+        return Err(CraftingError::SpecializationAlreadyChosen);
+    }
+
+    env.storage().persistent().set(
+        &CraftingDataKey::PlayerSpecialization(player.clone()),
+        &specialization,
+    );
+
+    env.events()
+        .publish((symbol_short!("spec"), player), symbol_short!("chosen"));
+
+    Ok(())
+}
+
+pub fn is_node_unlocked(env: &Env, player: &Address, node_id: u32) -> bool {
+    env.storage()
+        .persistent()
+        .get(&CraftingDataKey::UnlockedNode(player.clone(), node_id))
+        .unwrap_or(false)
+}
+
+/// Spend skill points to unlock a node in the player's chosen specialization
+/// tree. The node must belong to the player's specialization, must not
+/// already be unlocked, and the player must have enough skill points.
+pub fn unlock_skill_node(env: &Env, player: Address, node_id: u32) -> Result<(), CraftingError> {
+    player.require_auth();
+
+    let (_, node_spec, cost) = SKILL_TREE
+        .iter()
+        .find(|(id, _, _)| *id == node_id)
+        .ok_or(CraftingError::NodeNotFound)?;
+
+    let player_spec = get_specialization(env, &player).ok_or(CraftingError::WrongSpecialization)?;
+    if player_spec != *node_spec {
+        return Err(CraftingError::WrongSpecialization);
+    }
+
+    if is_node_unlocked(env, &player, node_id) {
+        return Err(CraftingError::NodeAlreadyUnlocked);
+    }
+
+    let points = get_skill_points(env, player.clone());
+    if points < *cost {
+        return Err(CraftingError::InsufficientSkillPoints);
+    }
+
+    env.storage().persistent().set(
+        &CraftingDataKey::SkillPoints(player.clone()),
+        &(points - *cost),
+    );
+    env.storage().persistent().set(
+        &CraftingDataKey::UnlockedNode(player.clone(), node_id),
+        &true,
+    );
+
+    env.events()
+        .publish((symbol_short!("skill"), player), node_id);
+
+    Ok(())
+}
+
+fn has_discovery_boost(env: &Env, player: &Address) -> bool {
+    DISCOVERY_NODES
+        .iter()
+        .any(|id| is_node_unlocked(env, player, *id))
+}
+
+pub fn get_mastery_count(env: &Env, player: &Address, recipe_id: u32) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&CraftingDataKey::MasteryCount(player.clone(), recipe_id))
+        .unwrap_or(0)
+}
+
+fn record_craft(env: &Env, player: &Address, recipe_id: u32) -> u32 {
+    let count = get_mastery_count(env, player, recipe_id).saturating_add(1);
+    env.storage().persistent().set(
+        &CraftingDataKey::MasteryCount(player.clone(), recipe_id),
+        &count,
+    );
+    count
 }
 
 pub fn get_level(env: &Env, player: Address) -> u32 {
@@ -82,7 +271,11 @@ pub fn get_xp(env: &Env, player: Address) -> u32 {
         .unwrap_or(0)
 }
 
-fn require_resources(env: &Env, player: &Address, inputs: &Vec<(Symbol, u32)>) -> Result<(), CraftingError> {
+fn require_resources(
+    env: &Env,
+    player: &Address,
+    inputs: &Vec<(Symbol, u32)>,
+) -> Result<(), CraftingError> {
     for input in inputs.iter() {
         let (symbol, required) = input;
         let balance = get_resource_balance(env, player, symbol);
@@ -106,10 +299,8 @@ fn mint_resource(env: &Env, player: &Address, output: (Symbol, u32)) {
     let balance = get_resource_balance(env, player, symbol.clone());
     set_resource_balance(env, player, symbol, balance + amount);
 
-    env.events().publish(
-        (symbol_short!("crafted"), player.clone()),
-        amount,
-    );
+    env.events()
+        .publish((symbol_short!("crafted"), player.clone()), amount);
 }
 
 fn get_resource_balance(env: &Env, player: &Address, symbol: Symbol) -> u32 {
@@ -125,8 +316,8 @@ fn set_resource_balance(env: &Env, player: &Address, symbol: Symbol, amount: u32
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Env, Symbol, Vec};
     use crate::recipes::{self, Recipe};
+    use soroban_sdk::{testutils::Address as _, Env, Symbol, Vec};
 
     use soroban_sdk::{contract, contractimpl};
 
@@ -249,6 +440,151 @@ mod tests {
         env.as_contract(&id, || {
             let result = craft(env.clone(), player.clone(), 999);
             assert_eq!(result, Err(CraftingError::RecipeNotFound));
+        });
+    }
+
+    // ── Skill Trees (Issue #266) ────────────────────────────────────────────
+
+    #[test]
+    fn test_choose_specialization_once_only() {
+        let (env, id) = make_env();
+        let player = Address::generate(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&id, || {
+            choose_specialization(&env, player.clone(), Specialization::Metallurgy).unwrap();
+            assert_eq!(
+                get_specialization(&env, &player),
+                Some(Specialization::Metallurgy)
+            );
+
+            let result = choose_specialization(&env, player.clone(), Specialization::Alchemy);
+            assert_eq!(result, Err(CraftingError::SpecializationAlreadyChosen));
+        });
+    }
+
+    #[test]
+    fn test_craft_gated_by_specialization() {
+        let (env, id) = make_env();
+        let player = Address::generate(&env);
+        let ore = Symbol::new(&env, "ore");
+        let ingot = Symbol::new(&env, "ingot");
+
+        env.mock_all_auths();
+        env.as_contract(&id, || {
+            let recipe = make_recipe(&env, 1, 1, ore.clone(), ingot.clone());
+            recipes::set_recipe(&env, &recipe);
+            recipes::set_recipe_specialization(&env, 1, Specialization::Metallurgy);
+
+            seed_resource(&env, &player, ore.clone(), 10);
+
+            // No specialization chosen yet.
+            let result = craft(env.clone(), player.clone(), 1);
+            assert_eq!(result, Err(CraftingError::WrongSpecialization));
+
+            // Wrong specialization chosen.
+            choose_specialization(&env, player.clone(), Specialization::Alchemy).unwrap();
+            let result = craft(env.clone(), player.clone(), 1);
+            assert_eq!(result, Err(CraftingError::WrongSpecialization));
+        });
+    }
+
+    #[test]
+    fn test_craft_succeeds_with_matching_specialization() {
+        let (env, id) = make_env();
+        let player = Address::generate(&env);
+        let ore = Symbol::new(&env, "ore");
+        let ingot = Symbol::new(&env, "ingot");
+
+        env.mock_all_auths();
+        env.as_contract(&id, || {
+            let recipe = make_recipe(&env, 1, 1, ore.clone(), ingot.clone());
+            recipes::set_recipe(&env, &recipe);
+            recipes::set_recipe_specialization(&env, 1, Specialization::Metallurgy);
+
+            seed_resource(&env, &player, ore.clone(), 10);
+            choose_specialization(&env, player.clone(), Specialization::Metallurgy).unwrap();
+
+            assert!(craft(env.clone(), player.clone(), 1).is_ok());
+        });
+    }
+
+    #[test]
+    fn test_unlock_skill_node_flow() {
+        let (env, id) = make_env();
+        let player = Address::generate(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&id, || {
+            choose_specialization(&env, player.clone(), Specialization::Metallurgy).unwrap();
+
+            // No skill points yet.
+            let result = unlock_skill_node(&env, player.clone(), 1);
+            assert_eq!(result, Err(CraftingError::InsufficientSkillPoints));
+
+            // Level the player up to 3 (100 xp per level) => 2 skill points.
+            add_xp(&env, player.clone(), 250);
+            assert_eq!(get_skill_points(&env, player.clone()), 2);
+
+            // Node 1 is Metallurgy, cost 1.
+            unlock_skill_node(&env, player.clone(), 1).unwrap();
+            assert!(is_node_unlocked(&env, &player, 1));
+            assert_eq!(get_skill_points(&env, player.clone()), 1);
+
+            // Already unlocked.
+            let result = unlock_skill_node(&env, player.clone(), 1);
+            assert_eq!(result, Err(CraftingError::NodeAlreadyUnlocked));
+
+            // Node 3 belongs to Alchemy, not the player's Metallurgy tree.
+            let result = unlock_skill_node(&env, player.clone(), 3);
+            assert_eq!(result, Err(CraftingError::WrongSpecialization));
+
+            // Unknown node.
+            let result = unlock_skill_node(&env, player.clone(), 999);
+            assert_eq!(result, Err(CraftingError::NodeNotFound));
+        });
+    }
+
+    #[test]
+    fn test_discovery_boost_active_with_keen_eye_node() {
+        let (env, id) = make_env();
+        let player = Address::generate(&env);
+
+        env.mock_all_auths();
+        env.as_contract(&id, || {
+            assert!(!has_discovery_boost(&env, &player));
+
+            choose_specialization(&env, player.clone(), Specialization::Engineering).unwrap();
+            add_xp(&env, player.clone(), 100); // level 2 => 1 skill point
+            unlock_skill_node(&env, player.clone(), 5).unwrap(); // Engineering keen-eye node
+
+            assert!(has_discovery_boost(&env, &player));
+        });
+    }
+
+    #[test]
+    fn test_mastery_bonus_grants_extra_output_after_interval() {
+        let (env, id) = make_env();
+        let player = Address::generate(&env);
+        let iron = Symbol::new(&env, "iron");
+        let steel = Symbol::new(&env, "steel");
+
+        env.mock_all_auths();
+        env.as_contract(&id, || {
+            let recipe = make_recipe(&env, 1, 1, iron.clone(), steel.clone());
+            recipes::set_recipe(&env, &recipe);
+            seed_resource(&env, &player, iron.clone(), 5 * MASTERY_INTERVAL);
+
+            for _ in 0..MASTERY_INTERVAL {
+                craft(env.clone(), player.clone(), 1).unwrap();
+            }
+
+            assert_eq!(get_mastery_count(&env, &player, 1), MASTERY_INTERVAL);
+
+            let key = (symbol_short!("res_bal"), player.clone(), steel.clone());
+            let out_bal: u32 = env.storage().instance().get(&key).unwrap_or(0);
+            // 9 crafts at base output 1, plus the 10th craft's +1 mastery bonus.
+            assert_eq!(out_bal, MASTERY_INTERVAL + 1);
         });
     }
 }

--- a/src/escrow_trader.rs
+++ b/src/escrow_trader.rs
@@ -1,5 +1,7 @@
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Symbol, Vec};
 
+use crate::reentrancy_guard::{with_guard, ReentrancyError};
+
 const ESCROW_EXPIRY: u64 = 172800;
 const MAX_CONCURRENT_ESCROWS: u32 = 5;
 
@@ -23,6 +25,14 @@ pub enum EscrowError {
     MaxEscrowsReached = 5,
     InvalidAssets = 6,
     NotFullyConfirmed = 7,
+    /// A guarded section was re-entered (Issue #238).
+    Reentrancy = 8,
+}
+
+impl From<ReentrancyError> for EscrowError {
+    fn from(_: ReentrancyError) -> Self {
+        EscrowError::Reentrancy
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -48,7 +58,7 @@ pub struct Escrow {
     pub expires_at: u64,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[contracttype]
 pub struct EscrowResult {
     pub escrow_id: u64,
@@ -84,7 +94,8 @@ pub fn initiate_escrow(
         .storage()
         .persistent()
         .get::<EscrowKey, u64>(&EscrowKey::EscrowCounter)
-        .unwrap_or(0) + 1;
+        .unwrap_or(0)
+        + 1;
 
     env.storage()
         .persistent()
@@ -110,13 +121,15 @@ pub fn initiate_escrow(
         .persistent()
         .set(&EscrowKey::EscrowData(escrow_counter), &escrow);
 
-    env.storage()
-        .persistent()
-        .set(&EscrowKey::PlayerEscrowCount(trader_a.clone()), &(escrow_count_a + 1));
+    env.storage().persistent().set(
+        &EscrowKey::PlayerEscrowCount(trader_a.clone()),
+        &(escrow_count_a + 1),
+    );
 
-    env.storage()
-        .persistent()
-        .set(&EscrowKey::EscrowConfirmation(escrow_counter, trader_a.clone()), &true);
+    env.storage().persistent().set(
+        &EscrowKey::EscrowConfirmation(escrow_counter, trader_a.clone()),
+        &true,
+    );
 
     env.events().publish(
         (symbol_short!("escrow"), symbol_short!("init")),
@@ -126,11 +139,7 @@ pub fn initiate_escrow(
     Ok(escrow)
 }
 
-pub fn confirm_escrow(
-    env: &Env,
-    escrow_id: u64,
-    trader: Address,
-) -> Result<Escrow, EscrowError> {
+pub fn confirm_escrow(env: &Env, escrow_id: u64, trader: Address) -> Result<Escrow, EscrowError> {
     trader.require_auth();
 
     let mut escrow = env
@@ -163,9 +172,10 @@ pub fn confirm_escrow(
         escrow.confirmed_b = true;
     }
 
-    env.storage()
-        .persistent()
-        .set(&EscrowKey::EscrowConfirmation(escrow_id, trader.clone()), &true);
+    env.storage().persistent().set(
+        &EscrowKey::EscrowConfirmation(escrow_id, trader.clone()),
+        &true,
+    );
 
     env.storage()
         .persistent()
@@ -174,72 +184,73 @@ pub fn confirm_escrow(
     Ok(escrow)
 }
 
-pub fn complete_escrow(
-    env: &Env,
-    escrow_id: u64,
-) -> Result<EscrowResult, EscrowError> {
-    let mut escrow = env
-        .storage()
-        .persistent()
-        .get::<EscrowKey, Escrow>(&EscrowKey::EscrowData(escrow_id))
-        .ok_or(EscrowError::EscrowNotFound)?;
+/// # Security
+/// * Holds a reentrancy guard across the confirmation-count decrements so a
+///   nested call cannot observe or double-spend the half-updated escrow
+///   state before settlement finishes (Issue #238).
+pub fn complete_escrow(env: &Env, escrow_id: u64) -> Result<EscrowResult, EscrowError> {
+    with_guard(env, || {
+        let mut escrow = env
+            .storage()
+            .persistent()
+            .get::<EscrowKey, Escrow>(&EscrowKey::EscrowData(escrow_id))
+            .ok_or(EscrowError::EscrowNotFound)?;
 
-    if env.ledger().timestamp() > escrow.expires_at {
-        return Err(EscrowError::TradeExpired);
-    }
+        if env.ledger().timestamp() > escrow.expires_at {
+            return Err(EscrowError::TradeExpired);
+        }
 
-    if !escrow.confirmed_a || !escrow.confirmed_b {
-        return Err(EscrowError::NotFullyConfirmed);
-    }
+        if !escrow.confirmed_a || !escrow.confirmed_b {
+            return Err(EscrowError::NotFullyConfirmed);
+        }
 
-    if escrow.completed {
-        return Err(EscrowError::AlreadyConfirmed);
-    }
+        if escrow.completed {
+            return Err(EscrowError::AlreadyConfirmed);
+        }
 
-    escrow.completed = true;
+        escrow.completed = true;
 
-    env.storage()
-        .persistent()
-        .set(&EscrowKey::EscrowData(escrow_id), &escrow);
+        env.storage()
+            .persistent()
+            .set(&EscrowKey::EscrowData(escrow_id), &escrow);
 
-    let count_a = env
-        .storage()
-        .persistent()
-        .get::<EscrowKey, u32>(&EscrowKey::PlayerEscrowCount(escrow.trader_a.clone()))
-        .unwrap_or(1);
-    env.storage()
-        .persistent()
-        .set(&EscrowKey::PlayerEscrowCount(escrow.trader_a.clone()), &count_a.saturating_sub(1));
+        let count_a = env
+            .storage()
+            .persistent()
+            .get::<EscrowKey, u32>(&EscrowKey::PlayerEscrowCount(escrow.trader_a.clone()))
+            .unwrap_or(1);
+        env.storage().persistent().set(
+            &EscrowKey::PlayerEscrowCount(escrow.trader_a.clone()),
+            &count_a.saturating_sub(1),
+        );
 
-    let count_b = env
-        .storage()
-        .persistent()
-        .get::<EscrowKey, u32>(&EscrowKey::PlayerEscrowCount(escrow.trader_b.clone()))
-        .unwrap_or(1);
-    env.storage()
-        .persistent()
-        .set(&EscrowKey::PlayerEscrowCount(escrow.trader_b.clone()), &count_b.saturating_sub(1));
+        let count_b = env
+            .storage()
+            .persistent()
+            .get::<EscrowKey, u32>(&EscrowKey::PlayerEscrowCount(escrow.trader_b.clone()))
+            .unwrap_or(1);
+        env.storage().persistent().set(
+            &EscrowKey::PlayerEscrowCount(escrow.trader_b.clone()),
+            &count_b.saturating_sub(1),
+        );
 
-    let result = EscrowResult {
-        escrow_id,
-        trader_a: escrow.trader_a.clone(),
-        trader_b: escrow.trader_b.clone(),
-        completed: true,
-    };
+        let result = EscrowResult {
+            escrow_id,
+            trader_a: escrow.trader_a.clone(),
+            trader_b: escrow.trader_b.clone(),
+            completed: true,
+        };
 
-    env.events().publish(
-        (symbol_short!("escrow"), symbol_short!("complete")),
-        (escrow_id, escrow.trader_a, escrow.trader_b),
-    );
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("complete")),
+            (escrow_id, escrow.trader_a, escrow.trader_b),
+        );
 
-    Ok(result)
+        Ok(result)
+    })
 }
 
-pub fn cancel_escrow(
-    env: &Env,
-    escrow_id: u64,
-    trader: Address,
-) -> Result<(), EscrowError> {
+pub fn cancel_escrow(env: &Env, escrow_id: u64, trader: Address) -> Result<(), EscrowError> {
     trader.require_auth();
 
     let escrow = env
@@ -265,9 +276,10 @@ pub fn cancel_escrow(
         .persistent()
         .get::<EscrowKey, u32>(&EscrowKey::PlayerEscrowCount(trader.clone()))
         .unwrap_or(1);
-    env.storage()
-        .persistent()
-        .set(&EscrowKey::PlayerEscrowCount(trader.clone()), &count.saturating_sub(1));
+    env.storage().persistent().set(
+        &EscrowKey::PlayerEscrowCount(trader.clone()),
+        &count.saturating_sub(1),
+    );
 
     env.events().publish(
         (symbol_short!("escrow"), symbol_short!("cancel")),
@@ -281,4 +293,82 @@ pub fn get_escrow(env: &Env, escrow_id: u64) -> Option<Escrow> {
     env.storage()
         .persistent()
         .get::<EscrowKey, Escrow>(&EscrowKey::EscrowData(escrow_id))
+}
+
+// ── Tests (Issue #238: reentrancy safety) ───────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{contract, contractimpl, testutils::Address as _};
+
+    #[contract]
+    struct Stub;
+    #[contractimpl]
+    impl Stub {}
+
+    fn make_env() -> (Env, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(Stub, ());
+        (env, contract_id)
+    }
+
+    fn open_and_confirm_escrow(env: &Env, trader_a: &Address, trader_b: &Address) -> u64 {
+        let mut assets_a = Vec::new(env);
+        assets_a.push_back(TradeAsset {
+            asset_type: Symbol::new(env, "ship"),
+            asset_id: 1,
+            quantity: 1,
+        });
+        let mut assets_b = Vec::new(env);
+        assets_b.push_back(TradeAsset {
+            asset_type: Symbol::new(env, "essence"),
+            asset_id: 0,
+            quantity: 100,
+        });
+
+        let escrow = initiate_escrow(env, trader_a.clone(), trader_b.clone(), assets_a, assets_b)
+            .expect("initiate_escrow should succeed");
+        confirm_escrow(env, escrow.escrow_id, trader_b.clone())
+            .expect("confirm_escrow should succeed");
+        escrow.escrow_id
+    }
+
+    #[test]
+    fn test_complete_escrow_rejected_while_guard_held() {
+        // Simulates a reentrant callback attempting to re-enter
+        // complete_escrow while a prior invocation's guard is held.
+        let (env, contract_id) = make_env();
+        let trader_a = Address::generate(&env);
+        let trader_b = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let escrow_id = open_and_confirm_escrow(&env, &trader_a, &trader_b);
+
+            crate::reentrancy_guard::acquire(&env).expect("lock should be free");
+            let result = complete_escrow(&env, escrow_id);
+            assert_eq!(result, Err(EscrowError::Reentrancy));
+            crate::reentrancy_guard::release(&env);
+
+            // Once released, completion succeeds normally.
+            let result = complete_escrow(&env, escrow_id).expect("complete_escrow should succeed");
+            assert!(result.completed);
+        });
+    }
+
+    #[test]
+    fn test_complete_escrow_twice_rejected() {
+        let (env, contract_id) = make_env();
+        let trader_a = Address::generate(&env);
+        let trader_b = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let escrow_id = open_and_confirm_escrow(&env, &trader_a, &trader_b);
+
+            complete_escrow(&env, escrow_id).expect("first completion should succeed");
+            let result = complete_escrow(&env, escrow_id);
+            assert_eq!(result, Err(EscrowError::AlreadyConfirmed));
+        });
+    }
 }

--- a/src/leaderboards.rs
+++ b/src/leaderboards.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, String, Vec, Symbol, Map};
+use soroban_sdk::{
+    contracterror, contracttype, symbol_short, Address, Env, Map, String, Symbol, Vec,
+};
 
 // Symbol::to_string() is implemented for non-wasm targets only (requires std::string::String).
 #[cfg(not(target_family = "wasm"))]
@@ -26,6 +28,8 @@ pub enum LeaderboardError {
     LeaderboardFull = 6,
     /// Reset is not yet due.
     ResetNotDue = 7,
+    /// Admin has already been set; set_admin is a one-time initializer (Issue #237).
+    AlreadyInitialized = 8,
 }
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
@@ -137,17 +141,22 @@ pub const REGION_OCEANIA: &str = "oceania";
 
 // ── Admin Functions ──────────────────────────────────────────────────────────
 
-pub fn set_admin(env: &Env, admin: &Address) {
+/// Bootstrap the leaderboard admin. Callable exactly once — subsequent calls
+/// return `AlreadyInitialized` instead of letting any caller overwrite the
+/// admin (Issue #237: this previously let anyone re-appoint themselves).
+pub fn set_admin(env: &Env, admin: &Address) -> Result<(), LeaderboardError> {
     admin.require_auth();
+    if get_admin(env).is_some() {
+        return Err(LeaderboardError::AlreadyInitialized);
+    }
     env.storage()
         .persistent()
         .set(&LeaderboardDataKey::Admin, admin);
+    Ok(())
 }
 
 fn get_admin(env: &Env) -> Option<Address> {
-    env.storage()
-        .persistent()
-        .get(&LeaderboardDataKey::Admin)
+    env.storage().persistent().get(&LeaderboardDataKey::Admin)
 }
 
 fn require_admin(env: &Env, caller: &Address) -> Result<(), LeaderboardError> {
@@ -498,7 +507,12 @@ pub fn distribute_rewards(
             if reward > 0 {
                 env.events().publish(
                     (symbol_short!("lb"), symbol_short!("reward")),
-                    (entry.player.clone(), reward, category.clone(), time_period.clone()),
+                    (
+                        entry.player.clone(),
+                        reward,
+                        category.clone(),
+                        time_period.clone(),
+                    ),
                 );
             }
         }
@@ -536,7 +550,8 @@ pub fn reset_leaderboard(
         .get(&board_key)
         .unwrap_or_else(|| Vec::new(env));
 
-    let archive_key = LeaderboardDataKey::Archive(category.clone(), time_period.clone(), current_season);
+    let archive_key =
+        LeaderboardDataKey::Archive(category.clone(), time_period.clone(), current_season);
     env.storage().persistent().set(&archive_key, &entries);
 
     // Clear the live board
@@ -545,14 +560,16 @@ pub fn reset_leaderboard(
 
     // Bump season
     let new_season = current_season + 1;
-    env.storage()
-        .persistent()
-        .set(&LeaderboardDataKey::Season(category.clone(), time_period.clone()), &new_season);
+    env.storage().persistent().set(
+        &LeaderboardDataKey::Season(category.clone(), time_period.clone()),
+        &new_season,
+    );
 
     // Record reset timestamp
-    env.storage()
-        .persistent()
-        .set(&LeaderboardDataKey::LastReset(category.clone(), time_period.clone()), &env.ledger().timestamp());
+    env.storage().persistent().set(
+        &LeaderboardDataKey::LastReset(category.clone(), time_period.clone()),
+        &env.ledger().timestamp(),
+    );
 
     env.events().publish(
         (symbol_short!("lb"), symbol_short!("reset")),
@@ -610,7 +627,10 @@ pub fn reset_if_due(
     let last_reset: Option<u64> = env
         .storage()
         .persistent()
-        .get(&LeaderboardDataKey::LastReset(category.clone(), time_period.clone()));
+        .get(&LeaderboardDataKey::LastReset(
+            category.clone(),
+            time_period.clone(),
+        ));
 
     let due = match last_reset {
         None => true,
@@ -804,13 +824,41 @@ mod tests {
     }
 
     #[test]
+    fn test_set_admin_cannot_be_hijacked_after_init() {
+        // Issue #237: set_admin previously let ANY caller overwrite the
+        // admin at any time (it only required the *new* admin's own
+        // signature, never the existing admin's). Now it is a one-time
+        // initializer.
+        let (env, _contract_id) = make_env();
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        env.as_contract(&_contract_id, || {
+            set_admin(&env, &admin).unwrap();
+
+            let result = set_admin(&env, &attacker);
+            assert_eq!(result, Err(LeaderboardError::AlreadyInitialized));
+
+            // Attacker still cannot perform admin-gated actions.
+            let result = reset_leaderboard(
+                &env,
+                &attacker,
+                Symbol::new(&env, CATEGORY_ESSENCE),
+                Symbol::new(&env, PERIOD_WEEKLY),
+            );
+            assert_eq!(result, Err(LeaderboardError::Unauthorized));
+        });
+    }
+
+    #[test]
     fn test_guild_leaderboard() {
         let (env, _contract_id) = make_env();
         let admin = Address::generate(&env);
 
         env.as_contract(&_contract_id, || {
-            set_admin(&env, &admin);
-            update_guild_score(&env, &admin, String::from_str(&env, "Test Guild"), 1000, 10).unwrap();
+            set_admin(&env, &admin).unwrap();
+            update_guild_score(&env, &admin, String::from_str(&env, "Test Guild"), 1000, 10)
+                .unwrap();
             let board = get_guild_leaderboard(&env, 10);
             assert_eq!(board.len(), 1);
         });
@@ -839,7 +887,7 @@ mod tests {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            set_admin(&env, &admin);
+            set_admin(&env, &admin).unwrap();
             update_score(&env, &player, category.clone(), period.clone(), 500).unwrap();
 
             // Confirm live board has 1 entry
@@ -847,7 +895,8 @@ mod tests {
             assert_eq!(board.len(), 1);
 
             // Reset; season 1 → 2
-            let new_season = reset_leaderboard(&env, &admin, category.clone(), period.clone()).unwrap();
+            let new_season =
+                reset_leaderboard(&env, &admin, category.clone(), period.clone()).unwrap();
             assert_eq!(new_season, 2);
 
             // Live board is empty
@@ -855,7 +904,8 @@ mod tests {
             assert_eq!(board.len(), 0);
 
             // Season 1 archive has the entry
-            let archived = get_archived_leaderboard(&env, category.clone(), period.clone(), 1, 10).unwrap();
+            let archived =
+                get_archived_leaderboard(&env, category.clone(), period.clone(), 1, 10).unwrap();
             assert_eq!(archived.len(), 1);
             assert_eq!(archived.get(0).unwrap().score, 500);
         });
@@ -871,17 +921,19 @@ mod tests {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            set_admin(&env, &admin);
+            set_admin(&env, &admin).unwrap();
             update_score(&env, &player, category.clone(), period.clone(), 200).unwrap();
             reset_leaderboard(&env, &admin, category.clone(), period.clone()).unwrap();
 
             // Season 1 archive has the entry
-            let archived = get_archived_leaderboard(&env, category.clone(), period.clone(), 1, 10).unwrap();
+            let archived =
+                get_archived_leaderboard(&env, category.clone(), period.clone(), 1, 10).unwrap();
             assert_eq!(archived.len(), 1);
             assert_eq!(archived.get(0).unwrap().score, 200);
 
             // Season 2 archive is empty (no reset happened yet for season 2)
-            let empty = get_archived_leaderboard(&env, category.clone(), period.clone(), 2, 10).unwrap();
+            let empty =
+                get_archived_leaderboard(&env, category.clone(), period.clone(), 2, 10).unwrap();
             assert_eq!(empty.len(), 0);
         });
     }
@@ -895,12 +947,18 @@ mod tests {
 
         env.mock_all_auths();
         env.as_contract(&contract_id, || {
-            set_admin(&env, &admin);
+            set_admin(&env, &admin).unwrap();
             // Default season is 1
-            assert_eq!(get_current_season(&env, category.clone(), period.clone()), 1);
+            assert_eq!(
+                get_current_season(&env, category.clone(), period.clone()),
+                1
+            );
             // After reset, season becomes 2
             reset_leaderboard(&env, &admin, category.clone(), period.clone()).unwrap();
-            assert_eq!(get_current_season(&env, category.clone(), period.clone()), 2);
+            assert_eq!(
+                get_current_season(&env, category.clone(), period.clone()),
+                2
+            );
         });
     }
 
@@ -919,11 +977,14 @@ mod tests {
         });
 
         env.as_contract(&contract_id, || {
-            set_admin(&env, &admin);
+            set_admin(&env, &admin).unwrap();
 
             // First call: no LastReset → treat as due → resets → true
             let result = reset_if_due(&env, &admin, category.clone(), period.clone()).unwrap();
-            assert!(result, "initial reset_if_due should return true (no LastReset)");
+            assert!(
+                result,
+                "initial reset_if_due should return true (no LastReset)"
+            );
 
             // LastReset is now 1000; advance to just before the weekly duration elapses
             env.ledger().with_mut(|li| {
@@ -931,7 +992,10 @@ mod tests {
             });
 
             let result = reset_if_due(&env, &admin, category.clone(), period.clone()).unwrap();
-            assert!(!result, "reset_if_due should be false before duration elapses");
+            assert!(
+                !result,
+                "reset_if_due should be false before duration elapses"
+            );
 
             // Advance past the weekly duration
             env.ledger().with_mut(|li| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,8 +339,13 @@ pub use trading::{
     MAX_SLIPPAGE_BPS, AMM_MAX_ROUTE_HOPS, SWAP_FEE_BPS,
 };
 
-pub use crafting::{craft, add_xp, get_level, get_xp};
-pub use recipes::{RecipeError, set_recipe, unlock_rare_recipe};
+pub use crafting::{
+    craft, add_xp, get_level, get_xp, CraftingError,
+    // Skill trees (Issue #266)
+    choose_specialization, get_specialization, get_skill_points,
+    unlock_skill_node, is_node_unlocked, get_mastery_count,
+};
+pub use recipes::{RecipeError, Specialization, set_recipe, set_recipe_specialization, unlock_rare_recipe};
 pub use nomad_bonding::{
     BondError, BondStatus, NomadBond, YieldDelegation,
     create_bond, accept_bond, delegate_yield, claim_yield, dissolve_bond,
@@ -510,8 +515,8 @@ impl NebulaNomadContract {
         leaderboards::distribute_rewards(&env, &caller, category, time_period, rewards)
     }
 
-    /// Set leaderboard admin (admin only).
-    pub fn set_leaderboard_admin(env: Env, admin: Address) {
+    /// Set leaderboard admin (one-time initializer).
+    pub fn set_leaderboard_admin(env: Env, admin: Address) -> Result<(), LeaderboardError> {
         leaderboards::set_admin(&env, &admin)
     }
 
@@ -637,8 +642,8 @@ impl NebulaNomadContract {
         content_tools::get_marketplace_listing(&env, listing_id)
     }
 
-    /// Set content tools admin (admin only).
-    pub fn set_content_admin(env: Env, admin: Address) {
+    /// Set content tools admin (one-time initializer).
+    pub fn set_content_admin(env: Env, admin: Address) -> Result<(), ContentToolsError> {
         content_tools::set_admin(&env, &admin)
     }
 
@@ -865,8 +870,8 @@ impl NebulaNomadContract {
         pvp_combat::get_rewards_config(&env)
     }
 
-    /// Set PvP combat admin (admin only).
-    pub fn set_pvp_admin(env: Env, admin: Address) {
+    /// Set PvP combat admin (one-time initializer).
+    pub fn set_pvp_admin(env: Env, admin: Address) -> Result<(), PvPError> {
         pvp_combat::set_admin(&env, &admin)
     }
 

--- a/src/nomad_bonding.rs
+++ b/src/nomad_bonding.rs
@@ -1,5 +1,7 @@
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env};
 
+use crate::reentrancy_guard::{with_guard, ReentrancyError};
+
 /// ── Errors ────────────────────────────────────────────────────────────────
 ///
 /// Yield delegation moves financial value between bonded players, so every
@@ -33,6 +35,14 @@ pub enum BondError {
     NotBondParty = 11,
     /// A checked arithmetic operation overflowed.
     ArithmeticOverflow = 12,
+    /// A guarded section was re-entered (Issue #238).
+    Reentrancy = 13,
+}
+
+impl From<ReentrancyError> for BondError {
+    fn from(_: ReentrancyError) -> Self {
+        BondError::Reentrancy
+    }
 }
 
 /// ── Storage Keys ──────────────────────────────────────────────────────────
@@ -96,7 +106,9 @@ fn next_bond_id(env: &Env) -> Result<u64, BondError> {
         .instance()
         .get(&DataKey::BondCounter)
         .unwrap_or(0);
-    let next = current.checked_add(1).ok_or(BondError::ArithmeticOverflow)?;
+    let next = current
+        .checked_add(1)
+        .ok_or(BondError::ArithmeticOverflow)?;
     env.storage().instance().set(&DataKey::BondCounter, &next);
     Ok(next)
 }
@@ -108,9 +120,7 @@ fn next_bond_id(env: &Env) -> Result<u64, BondError> {
 /// surface [`BondError::ArithmeticOverflow`] instead of panicking. Kept as a
 /// standalone, side-effect-free function so it can be property-tested directly.
 fn calculate_yield_amount(balance: u64, percentage: u32) -> Option<u64> {
-    balance
-        .checked_mul(percentage as u64)?
-        .checked_div(100)
+    balance.checked_mul(percentage as u64)?.checked_div(100)
 }
 
 /// ── create_bond ───────────────────────────────────────────────────────────
@@ -303,83 +313,89 @@ pub fn accrue_essence(env: &Env, player: &Address, amount: u64) -> Result<(), Bo
 /// * [`BondError::NoDelegation`] if no delegation is configured for the bond.
 /// * [`BondError::NotBeneficiary`] if the caller is not the beneficiary.
 /// * [`BondError::ArithmeticOverflow`] if any balance calculation overflows.
+/// # Security
+/// * Holds a reentrancy guard across the debit/credit sequence so a
+///   malicious `require_auth` callback (e.g. a custom-account contract)
+///   cannot re-enter `claim_yield` mid-transfer (Issue #238).
 pub fn claim_yield(env: &Env, claimer: &Address, bond_id: u64) -> Result<u64, BondError> {
     claimer.require_auth();
 
-    let bond: NomadBond = env
-        .storage()
-        .instance()
-        .get(&DataKey::Bond(bond_id))
-        .ok_or(BondError::BondNotFound)?;
+    with_guard(env, || {
+        let bond: NomadBond = env
+            .storage()
+            .instance()
+            .get(&DataKey::Bond(bond_id))
+            .ok_or(BondError::BondNotFound)?;
 
-    if bond.status != BondStatus::Active {
-        return Err(BondError::BondNotActive);
-    }
+        if bond.status != BondStatus::Active {
+            return Err(BondError::BondNotActive);
+        }
 
-    let mut delegation: YieldDelegation = env
-        .storage()
-        .instance()
-        .get(&DataKey::YieldDel(bond_id))
-        .ok_or(BondError::NoDelegation)?;
+        let mut delegation: YieldDelegation = env
+            .storage()
+            .instance()
+            .get(&DataKey::YieldDel(bond_id))
+            .ok_or(BondError::NoDelegation)?;
 
-    if *claimer != delegation.beneficiary {
-        return Err(BondError::NotBeneficiary);
-    }
+        if *claimer != delegation.beneficiary {
+            return Err(BondError::NotBeneficiary);
+        }
 
-    let delegator_balance: u64 = env
-        .storage()
-        .instance()
-        .get(&DataKey::Essence(delegation.delegator.clone()))
-        .unwrap_or(0);
+        let delegator_balance: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Essence(delegation.delegator.clone()))
+            .unwrap_or(0);
 
-    if delegator_balance == 0 {
-        return Ok(0);
-    }
+        if delegator_balance == 0 {
+            return Ok(0);
+        }
 
-    // Checked: balance * percentage / 100 cannot overflow silently.
-    let yield_amount = calculate_yield_amount(delegator_balance, delegation.percentage)
-        .ok_or(BondError::ArithmeticOverflow)?;
+        // Checked: balance * percentage / 100 cannot overflow silently.
+        let yield_amount = calculate_yield_amount(delegator_balance, delegation.percentage)
+            .ok_or(BondError::ArithmeticOverflow)?;
 
-    if yield_amount == 0 {
-        return Ok(0);
-    }
+        if yield_amount == 0 {
+            return Ok(0);
+        }
 
-    // Debit delegator (checked: yield_amount <= delegator_balance, but verified).
-    let new_delegator_balance = delegator_balance
-        .checked_sub(yield_amount)
-        .ok_or(BondError::ArithmeticOverflow)?;
-    env.storage().instance().set(
-        &DataKey::Essence(delegation.delegator.clone()),
-        &new_delegator_balance,
-    );
+        // Debit delegator (checked: yield_amount <= delegator_balance, but verified).
+        let new_delegator_balance = delegator_balance
+            .checked_sub(yield_amount)
+            .ok_or(BondError::ArithmeticOverflow)?;
+        env.storage().instance().set(
+            &DataKey::Essence(delegation.delegator.clone()),
+            &new_delegator_balance,
+        );
 
-    // Credit beneficiary (checked add).
-    let claimer_balance: u64 = env
-        .storage()
-        .instance()
-        .get(&DataKey::Essence(claimer.clone()))
-        .unwrap_or(0);
-    let new_claimer_balance = claimer_balance
-        .checked_add(yield_amount)
-        .ok_or(BondError::ArithmeticOverflow)?;
-    env.storage()
-        .instance()
-        .set(&DataKey::Essence(claimer.clone()), &new_claimer_balance);
+        // Credit beneficiary (checked add).
+        let claimer_balance: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Essence(claimer.clone()))
+            .unwrap_or(0);
+        let new_claimer_balance = claimer_balance
+            .checked_add(yield_amount)
+            .ok_or(BondError::ArithmeticOverflow)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::Essence(claimer.clone()), &new_claimer_balance);
 
-    delegation.total_yielded = delegation
-        .total_yielded
-        .checked_add(yield_amount)
-        .ok_or(BondError::ArithmeticOverflow)?;
-    env.storage()
-        .instance()
-        .set(&DataKey::YieldDel(bond_id), &delegation);
+        delegation.total_yielded = delegation
+            .total_yielded
+            .checked_add(yield_amount)
+            .ok_or(BondError::ArithmeticOverflow)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::YieldDel(bond_id), &delegation);
 
-    env.events().publish(
-        (symbol_short!("yield"), symbol_short!("claimed")),
-        (bond_id, claimer.clone(), yield_amount),
-    );
+        env.events().publish(
+            (symbol_short!("yield"), symbol_short!("claimed")),
+            (bond_id, claimer.clone(), yield_amount),
+        );
 
-    Ok(yield_amount)
+        Ok(yield_amount)
+    })
 }
 
 /// ── dissolve_bond ─────────────────────────────────────────────────────────
@@ -513,7 +529,7 @@ mod tests {
     }
 
     // ── Storage & auth tests ──────────────────────────────────────────────────
-    use soroban_sdk::{testutils::Address as _, contract, contractimpl};
+    use soroban_sdk::{contract, contractimpl, testutils::Address as _};
 
     #[contract]
     struct Stub;
@@ -563,8 +579,8 @@ mod tests {
         env.mock_all_auths();
 
         env.as_contract(&contract_id, || {
-            let bond = create_bond(&env, &initiator, 1, &partner)
-                .expect("create_bond should succeed");
+            let bond =
+                create_bond(&env, &initiator, 1, &partner).expect("create_bond should succeed");
 
             assert_eq!(bond.initiator, initiator);
             assert_eq!(bond.partner, partner);
@@ -596,8 +612,8 @@ mod tests {
         env.mock_all_auths();
 
         env.as_contract(&contract_id, || {
-            let bond = create_bond(&env, &initiator, 1, &partner)
-                .expect("create_bond should succeed");
+            let bond =
+                create_bond(&env, &initiator, 1, &partner).expect("create_bond should succeed");
 
             let result = accept_bond(&env, &stranger, bond.bond_id);
             assert_eq!(result, Err(BondError::NotDesignatedPartner));
@@ -614,8 +630,8 @@ mod tests {
         env.mock_all_auths();
 
         env.as_contract(&contract_id, || {
-            let bond = create_bond(&env, &initiator, 1, &partner)
-                .expect("create_bond should succeed");
+            let bond =
+                create_bond(&env, &initiator, 1, &partner).expect("create_bond should succeed");
             let _ = accept_bond(&env, &partner, bond.bond_id);
 
             let result = dissolve_bond(&env, &stranger, bond.bond_id);
@@ -632,8 +648,8 @@ mod tests {
         env.mock_all_auths();
 
         env.as_contract(&contract_id, || {
-            let bond = create_bond(&env, &initiator, 1, &partner)
-                .expect("create_bond should succeed");
+            let bond =
+                create_bond(&env, &initiator, 1, &partner).expect("create_bond should succeed");
             let _ = accept_bond(&env, &partner, bond.bond_id);
 
             let result = claim_yield(&env, &partner, bond.bond_id);
@@ -650,8 +666,8 @@ mod tests {
         env.mock_all_auths();
 
         env.as_contract(&contract_id, || {
-            let bond = create_bond(&env, &initiator, 1, &partner)
-                .expect("create_bond should succeed");
+            let bond =
+                create_bond(&env, &initiator, 1, &partner).expect("create_bond should succeed");
             let _ = accept_bond(&env, &partner, bond.bond_id);
 
             let result = delegate_yield(&env, &initiator, bond.bond_id, 0);
@@ -659,6 +675,36 @@ mod tests {
 
             let result = delegate_yield(&env, &initiator, bond.bond_id, 101);
             assert_eq!(result, Err(BondError::InvalidPercentage));
+        });
+    }
+
+    #[test]
+    fn test_claim_yield_rejected_while_guard_held() {
+        // Simulates a reentrant callback (e.g. a malicious require_auth
+        // callback) attempting to re-enter claim_yield while a prior
+        // invocation's guard is still held (Issue #238).
+        let (env, contract_id) = make_env();
+        let initiator = Address::generate(&env);
+        let partner = Address::generate(&env);
+
+        env.mock_all_auths();
+
+        env.as_contract(&contract_id, || {
+            let bond =
+                create_bond(&env, &initiator, 1, &partner).expect("create_bond should succeed");
+            let _ = accept_bond(&env, &partner, bond.bond_id);
+            let _ = delegate_yield(&env, &initiator, bond.bond_id, 50);
+            let _ = accrue_essence(&env, &initiator, 1000);
+
+            crate::reentrancy_guard::acquire(&env).expect("lock should be free");
+            let result = claim_yield(&env, &partner, bond.bond_id);
+            assert_eq!(result, Err(BondError::Reentrancy));
+            crate::reentrancy_guard::release(&env);
+
+            // Once released, the call succeeds normally.
+            let amount = claim_yield(&env, &partner, bond.bond_id)
+                .expect("claim_yield should succeed once unlocked");
+            assert_eq!(amount, 500);
         });
     }
 
@@ -671,12 +717,12 @@ mod tests {
         env.mock_all_auths();
 
         env.as_contract(&contract_id, || {
-            let bond = create_bond(&env, &initiator, 1, &partner)
-                .expect("create_bond should succeed");
+            let bond =
+                create_bond(&env, &initiator, 1, &partner).expect("create_bond should succeed");
             assert_eq!(bond.status, BondStatus::Pending);
 
-            let bond = accept_bond(&env, &partner, bond.bond_id)
-                .expect("accept_bond should succeed");
+            let bond =
+                accept_bond(&env, &partner, bond.bond_id).expect("accept_bond should succeed");
             assert_eq!(bond.status, BondStatus::Active);
 
             let delegation = delegate_yield(&env, &initiator, bond.bond_id, 50)
@@ -684,11 +730,10 @@ mod tests {
             assert_eq!(delegation.percentage, 50);
             assert_eq!(delegation.beneficiary, partner);
 
-            let _ = accrue_essence(&env, &initiator, 1000)
-                .expect("accrue_essence should succeed");
+            let _ = accrue_essence(&env, &initiator, 1000).expect("accrue_essence should succeed");
 
-            let amount = claim_yield(&env, &partner, bond.bond_id)
-                .expect("claim_yield should succeed");
+            let amount =
+                claim_yield(&env, &partner, bond.bond_id).expect("claim_yield should succeed");
             assert_eq!(amount, 500);
 
             let bond = dissolve_bond(&env, &initiator, bond.bond_id)

--- a/src/pvp_combat.rs
+++ b/src/pvp_combat.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, String, Vec, Symbol, Map, BytesN};
+use soroban_sdk::{
+    contracterror, contracttype, symbol_short, Address, BytesN, Env, Map, String, Symbol, Vec,
+};
 
 // ── Error ─────────────────────────────────────────────────────────────────────
 
@@ -30,6 +32,8 @@ pub enum PvPError {
     NotInQueue = 11,
     /// Spectator limit reached.
     SpectatorLimitReached = 12,
+    /// Admin has already been set; set_admin is a one-time initializer (Issue #237).
+    AlreadyInitialized = 13,
 }
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
@@ -186,22 +190,24 @@ pub const ELO_DECAY_FLOOR: u32 = 1000;
 
 // ── Admin Functions ──────────────────────────────────────────────────────────
 
-pub fn set_admin(env: &Env, admin: &Address) {
+/// Bootstrap the PvP combat admin. Callable exactly once — subsequent calls
+/// return `AlreadyInitialized` instead of letting any caller overwrite the
+/// admin (Issue #237: this previously let anyone re-appoint themselves).
+pub fn set_admin(env: &Env, admin: &Address) -> Result<(), PvPError> {
     admin.require_auth();
-    let old_admin: Option<Address> = env.storage().persistent().get(&PvPDataKey::Admin);
-    env.storage()
-        .persistent()
-        .set(&PvPDataKey::Admin, admin);
+    if get_admin(env).is_some() {
+        return Err(PvPError::AlreadyInitialized);
+    }
+    env.storage().persistent().set(&PvPDataKey::Admin, admin);
     env.events().publish(
         (symbol_short!("pvp"), symbol_short!("admin_set")),
-        (old_admin, admin.clone()),
+        (Option::<Address>::None, admin.clone()),
     );
+    Ok(())
 }
 
 fn get_admin(env: &Env) -> Option<Address> {
-    env.storage()
-        .persistent()
-        .get(&PvPDataKey::Admin)
+    env.storage().persistent().get(&PvPDataKey::Admin)
 }
 
 fn require_admin(env: &Env, caller: &Address) -> Result<(), PvPError> {
@@ -217,28 +223,22 @@ fn require_admin(env: &Env, caller: &Address) -> Result<(), PvPError> {
 
 pub fn get_or_init_stats(env: &Env, player: &Address) -> CombatStats {
     let key = PvPDataKey::PlayerStats(player.clone());
-    let stats = env.storage()
-        .persistent()
-        .get(&key)
-        .unwrap_or(CombatStats {
-            wins: 0,
-            losses: 0,
-            draws: 0,
-            total_damage_dealt: 0,
-            total_damage_received: 0,
-            elo_rating: INITIAL_ELO,
-            combat_count: 0,
-        });
+    let stats = env.storage().persistent().get(&key).unwrap_or(CombatStats {
+        wins: 0,
+        losses: 0,
+        draws: 0,
+        total_damage_dealt: 0,
+        total_damage_received: 0,
+        elo_rating: INITIAL_ELO,
+        combat_count: 0,
+    });
 
     // Apply ELO decay on any access
     apply_elo_decay(env, player);
     update_last_active(env, player);
 
     // Re-read after decay may have modified ELO
-    env.storage()
-        .persistent()
-        .get(&key)
-        .unwrap_or(stats)
+    env.storage().persistent().get(&key).unwrap_or(stats)
 }
 
 pub fn update_stats(env: &Env, player: &Address, stats: &CombatStats) {
@@ -258,10 +258,7 @@ pub fn get_combat_stats(env: &Env, player: &Address) -> CombatStats {
 
 pub fn get_elo_rating(env: &Env, player: &Address) -> u32 {
     let key = PvPDataKey::EloRating(player.clone());
-    env.storage()
-        .persistent()
-        .get(&key)
-        .unwrap_or(INITIAL_ELO)
+    env.storage().persistent().get(&key).unwrap_or(INITIAL_ELO)
 }
 
 pub fn update_elo_rating(env: &Env, player: &Address, new_rating: u32) {
@@ -275,8 +272,10 @@ pub fn update_elo_rating(env: &Env, player: &Address, new_rating: u32) {
 }
 
 fn calculate_elo_change(winner_rating: u32, loser_rating: u32) -> (u32, u32) {
-    let expected_winner = 1.0 / (1.0 + 10.0_f64.powf((loser_rating as f64 - winner_rating as f64) / 400.0));
-    let expected_loser = 1.0 / (1.0 + 10.0_f64.powf((winner_rating as f64 - loser_rating as f64) / 400.0));
+    let expected_winner =
+        1.0 / (1.0 + 10.0_f64.powf((loser_rating as f64 - winner_rating as f64) / 400.0));
+    let expected_loser =
+        1.0 / (1.0 + 10.0_f64.powf((winner_rating as f64 - loser_rating as f64) / 400.0));
 
     let winner_change = (K_FACTOR as f64 * (1.0 - expected_winner)).round() as u32;
     let loser_change = (K_FACTOR as f64 * (0.0 - expected_loser)).round().abs() as u32;
@@ -290,9 +289,7 @@ fn calculate_elo_change(winner_rating: u32, loser_rating: u32) -> (u32, u32) {
 pub fn update_last_active(env: &Env, player: &Address) {
     let key = PvPDataKey::LastActive(player.clone());
     let timestamp = env.ledger().timestamp();
-    env.storage()
-        .persistent()
-        .set(&key, &timestamp);
+    env.storage().persistent().set(&key, &timestamp);
     env.events().publish(
         (symbol_short!("pvp"), symbol_short!("last_act")),
         (player.clone(), timestamp),
@@ -317,7 +314,12 @@ pub fn set_elo_decay_config(
         .set(&PvPDataKey::EloDecayConfig, &config);
     env.events().publish(
         (symbol_short!("pvp"), symbol_short!("elo_cfg")),
-        (caller.clone(), config.inactivity_secs, config.decay_points, config.floor),
+        (
+            caller.clone(),
+            config.inactivity_secs,
+            config.decay_points,
+            config.floor,
+        ),
     );
     Ok(())
 }
@@ -354,8 +356,7 @@ pub fn apply_elo_decay(env: &Env, player: &Address) -> u32 {
 
     // Calculate how many full decay periods have elapsed
     let periods = inactive_duration / config.inactivity_secs;
-    let total_decay = (config.decay_points as u64)
-        .saturating_mul(periods as u64) as u32;
+    let total_decay = (config.decay_points as u64).saturating_mul(periods as u64) as u32;
 
     let current_elo = get_elo_rating(env, player);
     let new_elo = current_elo.saturating_sub(total_decay).max(config.floor);
@@ -447,11 +448,7 @@ pub fn create_challenge(
     Ok(challenge_id)
 }
 
-pub fn accept_challenge(
-    env: &Env,
-    caller: &Address,
-    challenge_id: u64,
-) -> Result<u64, PvPError> {
+pub fn accept_challenge(env: &Env, caller: &Address, challenge_id: u64) -> Result<u64, PvPError> {
     caller.require_auth();
 
     let key = PvPDataKey::Challenge(challenge_id);
@@ -487,11 +484,7 @@ pub fn accept_challenge(
     start_combat(env, &challenge.challenger, caller, challenge_id)
 }
 
-pub fn decline_challenge(
-    env: &Env,
-    caller: &Address,
-    challenge_id: u64,
-) -> Result<(), PvPError> {
+pub fn decline_challenge(env: &Env, caller: &Address, challenge_id: u64) -> Result<(), PvPError> {
     caller.require_auth();
 
     let key = PvPDataKey::Challenge(challenge_id);
@@ -546,7 +539,11 @@ pub fn start_combat(
     // Determine first turn randomly
     let now = env.ledger().timestamp();
     let seed = now % 2;
-    let turn = if seed == 0 { player1.clone() } else { player2.clone() };
+    let turn = if seed == 0 {
+        player1.clone()
+    } else {
+        player2.clone()
+    };
 
     let combat = CombatState {
         combat_id,
@@ -785,11 +782,7 @@ fn end_combat(env: &Env, combat: &mut CombatState) -> Result<(), PvPError> {
 
 fn record_combat_history(env: &Env, player: &Address, history: &CombatHistory) {
     let counter_key = PvPDataKey::CombatHistoryCounter(player.clone());
-    let counter: u64 = env
-        .storage()
-        .persistent()
-        .get(&counter_key)
-        .unwrap_or(0);
+    let counter: u64 = env.storage().persistent().get(&counter_key).unwrap_or(0);
 
     let history_key = PvPDataKey::CombatHistory(player.clone(), counter);
     env.storage().persistent().set(&history_key, history);
@@ -807,14 +800,14 @@ pub fn get_combat(env: &Env, combat_id: u64) -> Result<CombatState, PvPError> {
 
 pub fn get_player_combat_history(env: &Env, player: &Address, limit: u32) -> Vec<CombatHistory> {
     let counter_key = PvPDataKey::CombatHistoryCounter(player.clone());
-    let counter: u64 = env
-        .storage()
-        .persistent()
-        .get(&counter_key)
-        .unwrap_or(0);
+    let counter: u64 = env.storage().persistent().get(&counter_key).unwrap_or(0);
 
     let mut history = Vec::new(env);
-    let start = if counter > limit as u64 { counter - limit as u64 } else { 0 };
+    let start = if counter > limit as u64 {
+        counter - limit as u64
+    } else {
+        0
+    };
 
     for i in start..counter {
         let key = PvPDataKey::CombatHistory(player.clone(), i);
@@ -878,10 +871,7 @@ pub fn join_matchmaking(
     Ok(())
 }
 
-pub fn leave_matchmaking(
-    env: &Env,
-    player: &Address,
-) -> Result<(), PvPError> {
+pub fn leave_matchmaking(env: &Env, player: &Address) -> Result<(), PvPError> {
     player.require_auth();
 
     let key = PvPDataKey::MatchmakingQueue;
@@ -960,11 +950,7 @@ pub fn get_matchmaking_queue_size(env: &Env) -> u32 {
 
 // ── Spectator Mode ────────────────────────────────────────────────────────
 
-pub fn add_spectator(
-    env: &Env,
-    spectator: &Address,
-    combat_id: u64,
-) -> Result<(), PvPError> {
+pub fn add_spectator(env: &Env, spectator: &Address, combat_id: u64) -> Result<(), PvPError> {
     spectator.require_auth();
 
     let combat_key = PvPDataKey::Combat(combat_id);
@@ -979,14 +965,14 @@ pub fn add_spectator(
     }
 
     let spec_key = PvPDataKey::Spectators(combat_id);
-    let mut info: SpectatorInfo = env
-        .storage()
-        .persistent()
-        .get(&spec_key)
-        .unwrap_or(SpectatorInfo {
-            spectators: Vec::new(env),
-            max_spectators: MAX_SPECTATORS,
-        });
+    let mut info: SpectatorInfo =
+        env.storage()
+            .persistent()
+            .get(&spec_key)
+            .unwrap_or(SpectatorInfo {
+                spectators: Vec::new(env),
+                max_spectators: MAX_SPECTATORS,
+            });
 
     if info.spectators.len() >= info.max_spectators {
         return Err(PvPError::SpectatorLimitReached);
@@ -1012,11 +998,7 @@ pub fn add_spectator(
     Ok(())
 }
 
-pub fn remove_spectator(
-    env: &Env,
-    spectator: &Address,
-    combat_id: u64,
-) -> Result<(), PvPError> {
+pub fn remove_spectator(env: &Env, spectator: &Address, combat_id: u64) -> Result<(), PvPError> {
     spectator.require_auth();
 
     let spec_key = PvPDataKey::Spectators(combat_id);
@@ -1149,7 +1131,14 @@ mod tests {
             let combat = get_combat(&env, combat_id).unwrap();
             let first_player = combat.turn.clone();
 
-            execute_move(&env, &first_player, combat_id, Symbol::new(&env, "attack"), 10).unwrap();
+            execute_move(
+                &env,
+                &first_player,
+                combat_id,
+                Symbol::new(&env, "attack"),
+                10,
+            )
+            .unwrap();
 
             let updated = get_combat(&env, combat_id).unwrap();
             assert!(updated.player2_hp < 100 || updated.player1_hp < 100);
@@ -1171,6 +1160,34 @@ mod tests {
 
             let matched = process_matchmaking(&env).unwrap();
             assert!(matched.is_some());
+        });
+    }
+
+    #[test]
+    fn test_set_admin_cannot_be_hijacked_after_init() {
+        // Issue #237: set_admin previously let ANY caller overwrite the
+        // admin at any time. Now it is a one-time initializer.
+        let (env, _contract_id) = make_env();
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        env.as_contract(&_contract_id, || {
+            set_admin(&env, &admin).unwrap();
+
+            let result = set_admin(&env, &attacker);
+            assert_eq!(result, Err(PvPError::AlreadyInitialized));
+
+            let result = set_rewards_config(
+                &env,
+                &attacker,
+                RewardsConfig {
+                    base_reward: 999,
+                    win_bonus: 999,
+                    elo_bonus_multiplier: 1,
+                    streak_bonus: 0,
+                },
+            );
+            assert_eq!(result, Err(PvPError::Unauthorized));
         });
     }
 }

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -25,12 +25,26 @@ pub struct Recipe {
     pub required_level: u32,
 }
 
+/// Crafting skill specialization a recipe can belong to (Issue #266).
+///
+/// Recipes are not required to belong to a specialization — only recipes
+/// tagged via [`set_recipe_specialization`] gate on the player's chosen tree.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Specialization {
+    Metallurgy,
+    Alchemy,
+    Engineering,
+}
+
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 
 #[contracttype]
 pub enum RecipeKey {
     Recipe(u32),
     PlayerRareUnlocked(Address, u32),
+    /// Specialization a recipe is tagged with, if any (Issue #266).
+    RecipeSpecialization(u32),
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -67,4 +81,59 @@ pub fn unlock_rare_recipe(env: &Env, player: Address, recipe_id: u32) {
     env.storage()
         .instance()
         .set(&RecipeKey::PlayerRareUnlocked(player, recipe_id), &true);
+}
+
+/// Tag a recipe as belonging to a crafting specialization tree (Issue #266).
+///
+/// Untagged recipes remain craftable by anyone regardless of specialization.
+pub fn set_recipe_specialization(env: &Env, recipe_id: u32, specialization: Specialization) {
+    env.storage()
+        .instance()
+        .set(&RecipeKey::RecipeSpecialization(recipe_id), &specialization);
+}
+
+/// The specialization a recipe is tagged with, if any.
+pub fn get_recipe_specialization(env: &Env, recipe_id: u32) -> Option<Specialization> {
+    env.storage()
+        .instance()
+        .get(&RecipeKey::RecipeSpecialization(recipe_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{contract, contractimpl};
+
+    #[contract]
+    struct Stub;
+    #[contractimpl]
+    impl Stub {}
+
+    fn make_env() -> (Env, soroban_sdk::Address) {
+        let env = Env::default();
+        let id = env.register(Stub, ());
+        (env, id)
+    }
+
+    #[test]
+    fn test_recipe_specialization_defaults_to_none() {
+        let (env, id) = make_env();
+        env.as_contract(&id, || {
+            assert_eq!(get_recipe_specialization(&env, 1), None);
+        });
+    }
+
+    #[test]
+    fn test_set_and_get_recipe_specialization() {
+        let (env, id) = make_env();
+        env.as_contract(&id, || {
+            set_recipe_specialization(&env, 1, Specialization::Alchemy);
+            assert_eq!(
+                get_recipe_specialization(&env, 1),
+                Some(Specialization::Alchemy)
+            );
+            // Untagged recipes are unaffected.
+            assert_eq!(get_recipe_specialization(&env, 2), None);
+        });
+    }
 }

--- a/src/resource_minter.rs
+++ b/src/resource_minter.rs
@@ -9,11 +9,13 @@
 //   • RateLimitHit events are emitted inside check_rate_limit.
 
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror,
-                   log, symbol_short, Address, Env, String, Symbol};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, log, symbol_short, Address, Env, String,
+    Symbol,
+};
 
+use crate::nebula_gen::{NebulaError as NebulaGenError, NebulaGen};
 use crate::rate_limiter::{check_rate_limit, Operation, RateLimitError};
-use crate::nebula_gen::{NebulaGen, NebulaError as NebulaGenError};
 
 pub type AssetId = ResourceType;
 
@@ -43,10 +45,10 @@ pub enum ResourceType {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResourceRecord {
-    pub owner:         Address,
+    pub owner: Address,
     pub resource_type: ResourceType,
-    pub amount:        u64,
-    pub minted_at:     u64,
+    pub amount: u64,
+    pub minted_at: u64,
 }
 
 #[contracttype]
@@ -61,13 +63,15 @@ pub enum MinterKey {
 #[repr(u32)]
 pub enum MinterError {
     /// Amount must be > 0.
-    InvalidAmount       = 200,
+    InvalidAmount = 200,
     /// Caller exceeded the minting rate limit (DoS prevention).
-    RateLimitExceeded   = 201,
+    RateLimitExceeded = 201,
     /// No nebula layout found for this ship (must scan first).
-    NoLayoutForShip     = 202,
+    NoLayoutForShip = 202,
     /// The specified anomaly index does not contain a resource.
     NoResourceAtAnomaly = 203,
+    /// A checked arithmetic operation overflowed (Issue #239).
+    ArithmeticOverflow = 204,
 }
 
 impl From<RateLimitError> for MinterError {
@@ -82,24 +86,22 @@ pub struct ResourceMinterContract;
 
 #[contractimpl]
 impl ResourceMinterContract {
-
     /// Mint `amount` units of `resource_type` for `caller`.
     ///
     /// Rate-limited to prevent spam (Issue #175).
     pub fn mint_resource(
-        env:           &Env,
-        caller:        Address,
-        ship_id:       u64,
+        env: &Env,
+        caller: Address,
+        ship_id: u64,
         anomaly_index: u32,
         resource_type: ResourceType,
-        amount:        u64,
+        amount: u64,
     ) -> Result<ResourceRecord, MinterError> {
         // ── Auth ───────────────────────────────────────────────
         caller.require_auth();
 
         // ── Rate limit check (Issue #175) ──────────────────────
-        check_rate_limit(env, &caller, Operation::ResourceMinting)
-            .map_err(MinterError::from)?;
+        check_rate_limit(env, &caller, Operation::ResourceMinting).map_err(MinterError::from)?;
 
         // ── Basic validation ───────────────────────────────────
         if amount == 0 {
@@ -107,27 +109,32 @@ impl ResourceMinterContract {
         }
 
         // ── Confirm anomaly exists for this ship ───────────────
-        NebulaGen::has_anomaly(env.clone(), ship_id, anomaly_index)
-            .map_err(|e| match e {
-                NebulaGenError::LayoutNotFound    => MinterError::NoLayoutForShip,
-                NebulaGenError::AnomalyOutOfBounds => MinterError::NoResourceAtAnomaly,
-                _ => MinterError::NoLayoutForShip,
-            })?;
+        NebulaGen::has_anomaly(env.clone(), ship_id, anomaly_index).map_err(|e| match e {
+            NebulaGenError::LayoutNotFound => MinterError::NoLayoutForShip,
+            NebulaGenError::AnomalyOutOfBounds => MinterError::NoResourceAtAnomaly,
+            _ => MinterError::NoLayoutForShip,
+        })?;
 
-        // ── Update balances ────────────────────────────────────
+        // ── Update balances (checked: Issue #239) ──────────────
         let balance_key = MinterKey::Balance(caller.clone(), resource_type.clone());
         let current: u64 = env.storage().persistent().get(&balance_key).unwrap_or(0);
-        env.storage().persistent().set(&balance_key, &(current + amount));
+        let new_balance = current
+            .checked_add(amount)
+            .ok_or(MinterError::ArithmeticOverflow)?;
+        env.storage().persistent().set(&balance_key, &new_balance);
 
         let supply_key = MinterKey::TotalSupply(resource_type.clone());
         let supply: u64 = env.storage().persistent().get(&supply_key).unwrap_or(0);
-        env.storage().persistent().set(&supply_key, &(supply + amount));
+        let new_supply = supply
+            .checked_add(amount)
+            .ok_or(MinterError::ArithmeticOverflow)?;
+        env.storage().persistent().set(&supply_key, &new_supply);
 
         let record = ResourceRecord {
-            owner:         caller.clone(),
+            owner: caller.clone(),
             resource_type: resource_type.clone(),
             amount,
-            minted_at:     env.ledger().timestamp(),
+            minted_at: env.ledger().timestamp(),
         };
 
         // ── Emit event ─────────────────────────────────────────
@@ -140,11 +147,7 @@ impl ResourceMinterContract {
     }
 
     /// Query the balance of `owner` for `resource_type`.
-    pub fn balance(
-        env:           &Env,
-        owner:         Address,
-        resource_type: ResourceType,
-    ) -> u64 {
+    pub fn balance(env: &Env, owner: Address, resource_type: ResourceType) -> u64 {
         env.storage()
             .persistent()
             .get(&MinterKey::Balance(owner, resource_type))
@@ -174,19 +177,50 @@ mod tests {
         env
     }
 
+    // ── Arithmetic safety (Issue #239) ──────────────────────────
+    //
+    // `mint_resource` credits balances via `current.checked_add(amount)`
+    // (see above). These property tests pin down that operation's
+    // overflow behavior directly, independent of the full mint flow.
+    mod arithmetic_safety {
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn checked_credit_never_wraps(current in any::<u64>(), amount in any::<u64>()) {
+                match current.checked_add(amount) {
+                    Some(sum) => {
+                        prop_assert!(sum >= current);
+                        prop_assert!(sum >= amount);
+                    }
+                    None => {
+                        // Only reports overflow when the true (unbounded) sum
+                        // would actually exceed u64::MAX — never a false positive.
+                        prop_assert!(current as u128 + amount as u128 > u64::MAX as u128);
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn checked_credit_detects_overflow_at_max_balance() {
+            assert_eq!(u64::MAX.checked_add(1), None);
+            assert_eq!((u64::MAX - 1).checked_add(1), Some(u64::MAX));
+        }
+    }
+
     #[test]
     fn test_mint_zero_amount_rejected() {
-        let env    = make_env();
+        let env = make_env();
         let caller = Address::generate(&env);
-        let result = ResourceMinterContract::mint_resource(
-            &env, caller, 1, 0, ResourceType::StellarDust, 0,
-        );
+        let result =
+            ResourceMinterContract::mint_resource(&env, caller, 1, 0, ResourceType::StellarDust, 0);
         assert_eq!(result, Err(MinterError::InvalidAmount));
     }
 
     #[test]
     fn test_rate_limit_enforced_on_minting() {
-        let env    = make_env();
+        let env = make_env();
         let caller = Address::generate(&env);
 
         // Use up the default ResourceMinting limit (10 / 60 s)
@@ -194,11 +228,21 @@ mod tests {
         // but RateLimitExceeded must fire on the 11th.
         for _ in 0..10 {
             let _ = ResourceMinterContract::mint_resource(
-                &env, caller.clone(), 1, 0, ResourceType::StellarDust, 1,
+                &env,
+                caller.clone(),
+                1,
+                0,
+                ResourceType::StellarDust,
+                1,
             );
         }
         let result = ResourceMinterContract::mint_resource(
-            &env, caller.clone(), 1, 0, ResourceType::StellarDust, 1,
+            &env,
+            caller.clone(),
+            1,
+            0,
+            ResourceType::StellarDust,
+            1,
         );
         assert_eq!(result, Err(MinterError::RateLimitExceeded));
     }

--- a/src/trading.rs
+++ b/src/trading.rs
@@ -5,7 +5,9 @@
 //! Stop-loss orders are modelled as sell-side limit orders and executed
 //! by an off-chain keeper that calls `cancel_limit_order` + market sell.
 
-use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Symbol, Vec, Map};
+use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Map, Symbol, Vec};
+
+use crate::reentrancy_guard::{with_guard, ReentrancyError};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -150,11 +152,7 @@ pub fn place_limit_order(
 }
 
 /// Cancel an open limit order (owner only). Emits `OrderCancelled`.
-pub fn cancel_limit_order(
-    env: &Env,
-    trader: &Address,
-    order_id: u64,
-) -> Result<(), TradingError> {
+pub fn cancel_limit_order(env: &Env, trader: &Address, order_id: u64) -> Result<(), TradingError> {
     trader.require_auth();
 
     let order: LimitOrder = env
@@ -220,11 +218,7 @@ pub fn get_trader_orders(env: &Env, trader: &Address) -> Vec<LimitOrder> {
 }
 
 /// Record a completed trade in the history ring buffer. Emits `TradeExecuted`.
-pub fn record_trade(
-    env: &Env,
-    caller: &Address,
-    trade: TradeRecord,
-) -> Result<(), TradingError> {
+pub fn record_trade(env: &Env, caller: &Address, trade: TradeRecord) -> Result<(), TradingError> {
     caller.require_auth();
 
     let mut history: Vec<TradeRecord> = env
@@ -302,6 +296,14 @@ pub enum AmmError {
     InvalidRoute = 105,
     InsufficientLpTokens = 106,
     ZeroLiquidity = 107,
+    /// A guarded section was re-entered (Issue #238).
+    Reentrancy = 108,
+}
+
+impl From<ReentrancyError> for AmmError {
+    fn from(_: ReentrancyError) -> Self {
+        AmmError::Reentrancy
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -338,9 +340,7 @@ fn next_pool_id(env: &Env) -> u64 {
         .instance()
         .get(&AmmKey::PoolCounter)
         .unwrap_or(0);
-    env.storage()
-        .instance()
-        .set(&AmmKey::PoolCounter, &(n + 1));
+    env.storage().instance().set(&AmmKey::PoolCounter, &(n + 1));
     n + 1
 }
 
@@ -380,7 +380,11 @@ fn calculate_lp_mint(
     } else {
         let share_a = amount_a * total_supply / reserve_a;
         let share_b = amount_b * total_supply / reserve_b;
-        if share_a < share_b { share_a } else { share_b }
+        if share_a < share_b {
+            share_a
+        } else {
+            share_b
+        }
     }
 }
 
@@ -409,7 +413,11 @@ pub fn create_pool(
 
     for i in 0..pools.len() {
         if let Some(pid) = pools.get(i) {
-            if let Some(pool) = env.storage().persistent().get::<_, LiquidityPool>(&AmmKey::Pool(pid)) {
+            if let Some(pool) = env
+                .storage()
+                .persistent()
+                .get::<_, LiquidityPool>(&AmmKey::Pool(pid))
+            {
                 if (pool.resource_a == resource_a && pool.resource_b == resource_b)
                     || (pool.resource_a == resource_b && pool.resource_b == resource_a)
                 {
@@ -482,9 +490,18 @@ pub fn add_liquidity(
     }
 
     // Update reserves
-    pool.reserve_a = pool.reserve_a.checked_add(amount_a).ok_or(AmmError::InvalidAmount)?;
-    pool.reserve_b = pool.reserve_b.checked_add(amount_b).ok_or(AmmError::InvalidAmount)?;
-    pool.lp_total_supply = pool.lp_total_supply.checked_add(lp_mint).ok_or(AmmError::InvalidAmount)?;
+    pool.reserve_a = pool
+        .reserve_a
+        .checked_add(amount_a)
+        .ok_or(AmmError::InvalidAmount)?;
+    pool.reserve_b = pool
+        .reserve_b
+        .checked_add(amount_b)
+        .ok_or(AmmError::InvalidAmount)?;
+    pool.lp_total_supply = pool
+        .lp_total_supply
+        .checked_add(lp_mint)
+        .ok_or(AmmError::InvalidAmount)?;
 
     env.storage().persistent().set(&key, &pool);
 
@@ -544,9 +561,18 @@ pub fn remove_liquidity(
     let share_b = lp_amount * pool.reserve_b / pool.lp_total_supply;
 
     // Update reserves
-    pool.reserve_a = pool.reserve_a.checked_sub(share_a).ok_or(AmmError::InsufficientLiquidity)?;
-    pool.reserve_b = pool.reserve_b.checked_sub(share_b).ok_or(AmmError::InsufficientLiquidity)?;
-    pool.lp_total_supply = pool.lp_total_supply.checked_sub(lp_amount).ok_or(AmmError::InvalidAmount)?;
+    pool.reserve_a = pool
+        .reserve_a
+        .checked_sub(share_a)
+        .ok_or(AmmError::InsufficientLiquidity)?;
+    pool.reserve_b = pool
+        .reserve_b
+        .checked_sub(share_b)
+        .ok_or(AmmError::InsufficientLiquidity)?;
+    pool.lp_total_supply = pool
+        .lp_total_supply
+        .checked_sub(lp_amount)
+        .ok_or(AmmError::InvalidAmount)?;
 
     env.storage().persistent().set(&key, &pool);
 
@@ -570,6 +596,10 @@ pub fn remove_liquidity(
 ///
 /// `route` is a vec of pool_ids that form a chain: resource_in -> pool[0] -> ... -> pool[n] -> resource_out.
 /// For a single-pool swap, route contains exactly one pool_id.
+/// # Security
+/// * Holds a reentrancy guard across the full multi-hop reserve update
+///   sequence so a nested call cannot observe or trade against a
+///   partially-updated pool mid-route (Issue #238).
 pub fn swap_exact_input(
     env: &Env,
     trader: &Address,
@@ -587,65 +617,85 @@ pub fn swap_exact_input(
         return Err(AmmError::InvalidRoute);
     }
 
-    let mut current_amount = amount_in;
-    let resource_in_clone = resource_in.clone();
-    let mut current_resource = resource_in;
+    with_guard(env, || {
+        let mut current_amount = amount_in;
+        let resource_in_clone = resource_in.clone();
+        let mut current_resource = resource_in;
 
-    for i in 0..route.len() {
-        let pool_id = route.get(i).ok_or(AmmError::InvalidRoute)?;
-        let key = AmmKey::Pool(pool_id);
-        let pool: LiquidityPool = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .ok_or(AmmError::PoolNotFound)?;
+        for i in 0..route.len() {
+            let pool_id = route.get(i).ok_or(AmmError::InvalidRoute)?;
+            let key = AmmKey::Pool(pool_id);
+            let pool: LiquidityPool = env
+                .storage()
+                .persistent()
+                .get(&key)
+                .ok_or(AmmError::PoolNotFound)?;
 
-        let (reserve_in, reserve_out) = if pool.resource_a == current_resource {
-            (pool.reserve_a, pool.reserve_b)
-        } else if pool.resource_b == current_resource {
-            (pool.reserve_b, pool.reserve_a)
-        } else {
-            return Err(AmmError::InvalidRoute);
-        };
+            let (reserve_in, reserve_out) = if pool.resource_a == current_resource {
+                (pool.reserve_a, pool.reserve_b)
+            } else if pool.resource_b == current_resource {
+                (pool.reserve_b, pool.reserve_a)
+            } else {
+                return Err(AmmError::InvalidRoute);
+            };
 
-        if reserve_in <= 0 || reserve_out <= 0 {
-            return Err(AmmError::InsufficientLiquidity);
+            if reserve_in <= 0 || reserve_out <= 0 {
+                return Err(AmmError::InsufficientLiquidity);
+            }
+
+            let output = get_output_amount(current_amount, reserve_in, reserve_out, pool.fee_bps);
+            if output <= 0 {
+                return Err(AmmError::InsufficientLiquidity);
+            }
+
+            // Update pool reserves
+            let mut updated_pool = pool;
+            if updated_pool.resource_a == current_resource {
+                updated_pool.reserve_a = updated_pool
+                    .reserve_a
+                    .checked_add(current_amount)
+                    .ok_or(AmmError::InvalidAmount)?;
+                updated_pool.reserve_b = updated_pool
+                    .reserve_b
+                    .checked_sub(output)
+                    .ok_or(AmmError::InsufficientLiquidity)?;
+                current_resource = updated_pool.resource_b.clone();
+            } else {
+                updated_pool.reserve_b = updated_pool
+                    .reserve_b
+                    .checked_add(current_amount)
+                    .ok_or(AmmError::InvalidAmount)?;
+                updated_pool.reserve_a = updated_pool
+                    .reserve_a
+                    .checked_sub(output)
+                    .ok_or(AmmError::InsufficientLiquidity)?;
+                current_resource = updated_pool.resource_a.clone();
+            }
+
+            env.storage()
+                .persistent()
+                .set(&AmmKey::Pool(pool_id), &updated_pool);
+
+            current_amount = output;
         }
 
-        let output = get_output_amount(current_amount, reserve_in, reserve_out, pool.fee_bps);
-        if output <= 0 {
-            return Err(AmmError::InsufficientLiquidity);
+        if current_amount < min_amount_out {
+            return Err(AmmError::SlippageExceeded);
         }
 
-        // Update pool reserves
-        let mut updated_pool = pool;
-        if updated_pool.resource_a == current_resource {
-            updated_pool.reserve_a = updated_pool.reserve_a.checked_add(current_amount).ok_or(AmmError::InvalidAmount)?;
-            updated_pool.reserve_b = updated_pool.reserve_b.checked_sub(output).ok_or(AmmError::InsufficientLiquidity)?;
-            current_resource = updated_pool.resource_b.clone();
-        } else {
-            updated_pool.reserve_b = updated_pool.reserve_b.checked_add(current_amount).ok_or(AmmError::InvalidAmount)?;
-            updated_pool.reserve_a = updated_pool.reserve_a.checked_sub(output).ok_or(AmmError::InsufficientLiquidity)?;
-            current_resource = updated_pool.resource_a.clone();
-        }
+        env.events().publish(
+            (symbol_short!("amm"), symbol_short!("swap")),
+            (
+                trader.clone(),
+                resource_in_clone,
+                amount_in,
+                current_resource.clone(),
+                current_amount,
+            ),
+        );
 
-        env.storage()
-            .persistent()
-            .set(&AmmKey::Pool(pool_id), &updated_pool);
-
-        current_amount = output;
-    }
-
-    if current_amount < min_amount_out {
-        return Err(AmmError::SlippageExceeded);
-    }
-
-    env.events().publish(
-        (symbol_short!("amm"), symbol_short!("swap")),
-        (trader.clone(), resource_in_clone, amount_in, current_resource.clone(), current_amount),
-    );
-
-    Ok(current_amount)
+        Ok(current_amount)
+    })
 }
 
 /// Get pool details.
@@ -698,5 +748,81 @@ pub fn quote_swap(
         return Err(AmmError::InsufficientLiquidity);
     }
 
-    Ok(get_output_amount(amount_in, reserve_in, reserve_out, pool.fee_bps))
+    Ok(get_output_amount(
+        amount_in,
+        reserve_in,
+        reserve_out,
+        pool.fee_bps,
+    ))
+}
+
+// ── Tests (Issue #238: reentrancy safety) ───────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{contract, contractimpl, testutils::Address as _};
+
+    #[contract]
+    struct Stub;
+    #[contractimpl]
+    impl Stub {}
+
+    fn make_env() -> (Env, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(Stub, ());
+        (env, contract_id)
+    }
+
+    fn seed_pool(env: &Env, provider: &Address, resource_a: Symbol, resource_b: Symbol) -> u64 {
+        let pool_id = create_pool(env, provider, resource_a, resource_b).unwrap();
+        add_liquidity(env, provider, pool_id, 10_000, 10_000).unwrap();
+        pool_id
+    }
+
+    #[test]
+    fn test_swap_exact_input_rejected_while_guard_held() {
+        // Simulates a reentrant callback attempting to re-enter
+        // swap_exact_input while a prior invocation's guard is held.
+        let (env, contract_id) = make_env();
+        let provider = Address::generate(&env);
+        let trader = Address::generate(&env);
+        let resource_a = Symbol::new(&env, "stdust");
+        let resource_b = Symbol::new(&env, "drmatt");
+
+        env.as_contract(&contract_id, || {
+            let pool_id = seed_pool(&env, &provider, resource_a.clone(), resource_b.clone());
+            let mut route = Vec::new(&env);
+            route.push_back(pool_id);
+
+            crate::reentrancy_guard::acquire(&env).expect("lock should be free");
+            let result = swap_exact_input(&env, &trader, resource_a.clone(), 100, 0, route.clone());
+            assert_eq!(result, Err(AmmError::Reentrancy));
+            crate::reentrancy_guard::release(&env);
+
+            // Once released, the swap succeeds normally.
+            let out = swap_exact_input(&env, &trader, resource_a, 100, 0, route)
+                .expect("swap should succeed once unlocked");
+            assert!(out > 0);
+        });
+    }
+
+    #[test]
+    fn test_swap_exact_input_respects_slippage() {
+        let (env, contract_id) = make_env();
+        let provider = Address::generate(&env);
+        let trader = Address::generate(&env);
+        let resource_a = Symbol::new(&env, "stdust");
+        let resource_b = Symbol::new(&env, "drmatt");
+
+        env.as_contract(&contract_id, || {
+            let pool_id = seed_pool(&env, &provider, resource_a.clone(), resource_b.clone());
+            let mut route = Vec::new(&env);
+            route.push_back(pool_id);
+
+            let result = swap_exact_input(&env, &trader, resource_a, 100, i128::MAX, route);
+            assert_eq!(result, Err(AmmError::SlippageExceeded));
+        });
+    }
 }

--- a/src/treasure_vault.rs
+++ b/src/treasure_vault.rs
@@ -32,6 +32,8 @@ pub enum VaultError {
     AlreadyClaimed = 4,
     /// Deposit amount must be positive.
     InvalidAmount = 5,
+    /// A checked arithmetic operation overflowed (Issue #239).
+    ArithmeticOverflow = 6,
 }
 
 /// A time-locked treasure vault.
@@ -47,15 +49,27 @@ pub struct TreasureVault {
     pub claimed: bool,
 }
 
-fn next_vault_id(env: &Env) -> u64 {
+fn next_vault_id(env: &Env) -> Result<u64, VaultError> {
     let current: u64 = env
         .storage()
         .instance()
         .get(&VaultKey::VaultCounter)
         .unwrap_or(0);
-    let next = current + 1;
+    let next = current
+        .checked_add(1)
+        .ok_or(VaultError::ArithmeticOverflow)?;
     env.storage().instance().set(&VaultKey::VaultCounter, &next);
-    next
+    Ok(next)
+}
+
+/// Bonus yield for a claimed vault: `amount * bonus_multiplier / BPS_DENOM`,
+/// computed with checked arithmetic so an extreme `amount` reports overflow
+/// instead of silently wrapping (Issue #239).
+fn calculate_bonus_payout(amount: u64, bonus_multiplier: u64) -> Option<u64> {
+    let bonus = amount
+        .checked_mul(bonus_multiplier)?
+        .checked_div(BPS_DENOM)?;
+    amount.checked_add(bonus)
 }
 
 fn get_min_lock_duration(env: &Env) -> u64 {
@@ -83,8 +97,12 @@ pub fn deposit_treasure(
     }
 
     let min_lock = get_min_lock_duration(env);
-    let lock_until = env.ledger().timestamp() + min_lock;
-    let vault_id = next_vault_id(env);
+    let lock_until = env
+        .ledger()
+        .timestamp()
+        .checked_add(min_lock)
+        .ok_or(VaultError::ArithmeticOverflow)?;
+    let vault_id = next_vault_id(env)?;
 
     let vault = TreasureVault {
         vault_id,
@@ -135,9 +153,9 @@ pub fn claim_treasure(env: &Env, owner: &Address, vault_id: u64) -> Result<u64, 
         return Err(VaultError::StillLocked);
     }
 
-    // Calculate bonus yield
-    let bonus = vault.amount * vault.bonus_multiplier / BPS_DENOM;
-    let total_payout = vault.amount + bonus;
+    // Calculate bonus yield (checked: Issue #239)
+    let total_payout = calculate_bonus_payout(vault.amount, vault.bonus_multiplier)
+        .ok_or(VaultError::ArithmeticOverflow)?;
 
     vault.claimed = true;
     env.storage()
@@ -164,4 +182,76 @@ pub fn set_min_lock_duration(env: &Env, duration: u64) {
     env.storage()
         .instance()
         .set(&VaultKey::MinLockDuration, &duration);
+}
+
+// ── Tests (Issue #239: arithmetic safety) ───────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use soroban_sdk::{contract, contractimpl, testutils::Address as _};
+
+    #[contract]
+    struct Stub;
+    #[contractimpl]
+    impl Stub {}
+
+    fn make_env() -> (Env, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(Stub, ());
+        (env, contract_id)
+    }
+
+    #[test]
+    fn test_calculate_bonus_payout_matches_default_bonus() {
+        // BONUS_BPS = 1_000 (10%): 100 + 10% = 110.
+        assert_eq!(calculate_bonus_payout(100, BONUS_BPS), Some(110));
+    }
+
+    #[test]
+    fn test_calculate_bonus_payout_overflow_reported_not_wrapped() {
+        assert_eq!(calculate_bonus_payout(u64::MAX, BONUS_BPS), None);
+    }
+
+    proptest! {
+        /// The payout is always >= the original amount for any non-overflowing
+        /// input, and the helper never panics across the full u64 domain.
+        #[test]
+        fn bonus_payout_never_below_principal(amount in 0u64..=(u64::MAX / 10_000)) {
+            if let Some(payout) = calculate_bonus_payout(amount, BONUS_BPS) {
+                prop_assert!(payout >= amount);
+            }
+        }
+
+        #[test]
+        fn bonus_payout_never_panics(amount in any::<u64>(), multiplier in any::<u64>()) {
+            let _ = calculate_bonus_payout(amount, multiplier);
+        }
+    }
+
+    #[test]
+    fn test_deposit_then_claim_before_unlock_is_still_locked() {
+        let (env, contract_id) = make_env();
+        let owner = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let vault = deposit_treasure(&env, &owner, 1, 500).unwrap();
+            let result = claim_treasure(&env, &owner, vault.vault_id);
+            assert_eq!(result, Err(VaultError::StillLocked));
+        });
+    }
+
+    #[test]
+    fn test_vault_ids_increment_safely() {
+        let (env, contract_id) = make_env();
+        let owner = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let v1 = deposit_treasure(&env, &owner, 1, 100).unwrap();
+            let v2 = deposit_treasure(&env, &owner, 1, 100).unwrap();
+            assert_eq!(v2.vault_id, v1.vault_id + 1);
+        });
+    }
 }

--- a/src/yield_farming.rs
+++ b/src/yield_farming.rs
@@ -8,6 +8,8 @@ pub enum FarmError {
     InsufficientBalance = 2,
     InvalidPool = 3,
     WhaleCapExceeded = 4,
+    /// A checked arithmetic operation overflowed (Issue #239).
+    ArithmeticOverflow = 5,
 }
 
 #[contracttype]
@@ -25,15 +27,36 @@ const SECONDS_IN_YEAR: u64 = 31_536_000;
 const BASE_APY_BPS: i128 = 1500; // 15% Base APY
 const WHALE_CAP: i128 = 1_000_000_000_000; // 1M essence example cap
 
-pub fn deposit_to_pool(env: Env, owner: Address, amount: i128, lock_period: u32) -> Result<u64, FarmError> {
+/// Time-weighted linear APY reward for `amount` staked over `elapsed` seconds.
+///
+/// `reward = amount * BASE_APY_BPS * elapsed / (10_000 * SECONDS_IN_YEAR)`,
+/// computed with checked arithmetic so a pathological `amount`/`elapsed` pair
+/// overflows into `None` instead of silently wrapping (Issue #239).
+fn calculate_farm_reward(amount: i128, elapsed: u64) -> Option<i128> {
+    amount
+        .checked_mul(BASE_APY_BPS)?
+        .checked_mul(elapsed as i128)?
+        .checked_div(10_000_i128.checked_mul(SECONDS_IN_YEAR as i128)?)
+}
+
+pub fn deposit_to_pool(
+    env: Env,
+    owner: Address,
+    amount: i128,
+    lock_period: u32,
+) -> Result<u64, FarmError> {
     owner.require_auth();
 
     if amount > WHALE_CAP {
         return Err(FarmError::WhaleCapExceeded);
     }
 
-    let mut pool_id = env.storage().instance().get::<_, u64>(&symbol_short!("next_pid")).unwrap_or(0);
-    
+    let pool_id = env
+        .storage()
+        .instance()
+        .get::<_, u64>(&symbol_short!("next_pid"))
+        .unwrap_or(0);
+
     let pool = FarmPool {
         id: pool_id,
         owner: owner.clone(),
@@ -44,7 +67,12 @@ pub fn deposit_to_pool(env: Env, owner: Address, amount: i128, lock_period: u32)
     };
 
     env.storage().persistent().set(&pool_id, &pool);
-    env.storage().instance().set(&symbol_short!("next_pid"), &(pool_id + 1));
+    let next_pool_id = pool_id
+        .checked_add(1)
+        .ok_or(FarmError::ArithmeticOverflow)?;
+    env.storage()
+        .instance()
+        .set(&symbol_short!("next_pid"), &next_pool_id);
 
     env.events().publish(
         (symbol_short!("farm"), symbol_short!("deposit")),
@@ -57,22 +85,27 @@ pub fn deposit_to_pool(env: Env, owner: Address, amount: i128, lock_period: u32)
 pub fn harvest_farm_rewards(env: Env, owner: Address, pool_id: u64) -> Result<i128, FarmError> {
     owner.require_auth();
 
-    let mut pool: FarmPool = env.storage().persistent().get(&pool_id).ok_or(FarmError::InvalidPool)?;
-    
+    let mut pool: FarmPool = env
+        .storage()
+        .persistent()
+        .get(&pool_id)
+        .ok_or(FarmError::InvalidPool)?;
+
     if pool.owner != owner {
         return Err(FarmError::InvalidPool);
     }
 
     let now = env.ledger().timestamp();
     let elapsed = now.saturating_sub(pool.last_harvest);
-    
+
     if elapsed == 0 {
         return Ok(0);
     }
 
     // Time-weighted reward calculation (simple linear APY for MVP)
     // Reward = Amount * (APY / 10000) * (Elapsed / SECONDS_IN_YEAR)
-    let reward = (pool.amount * BASE_APY_BPS * elapsed as i128) / (10000 * SECONDS_IN_YEAR as i128);
+    let reward =
+        calculate_farm_reward(pool.amount, elapsed).ok_or(FarmError::ArithmeticOverflow)?;
 
     pool.last_harvest = now;
     env.storage().persistent().set(&pool_id, &pool);
@@ -88,21 +121,100 @@ pub fn harvest_farm_rewards(env: Env, owner: Address, pool_id: u64) -> Result<i1
 pub fn withdraw_from_pool(env: Env, owner: Address, pool_id: u64) -> Result<i128, FarmError> {
     owner.require_auth();
 
-    let pool: FarmPool = env.storage().persistent().get(&pool_id).ok_or(FarmError::InvalidPool)?;
-    
+    let pool: FarmPool = env
+        .storage()
+        .persistent()
+        .get(&pool_id)
+        .ok_or(FarmError::InvalidPool)?;
+
     if pool.owner != owner {
         return Err(FarmError::InvalidPool);
     }
 
     let now = env.ledger().timestamp();
-    if now < pool.start_time + pool.lock_period as u64 {
+    let unlock_at = pool
+        .start_time
+        .checked_add(pool.lock_period as u64)
+        .ok_or(FarmError::ArithmeticOverflow)?;
+    if now < unlock_at {
         return Err(FarmError::LockNotMet);
     }
 
     // Harvest remaining rewards first
     let reward = harvest_farm_rewards(env.clone(), owner.clone(), pool_id)?;
-    
+
     env.storage().persistent().remove(&pool_id);
 
-    Ok(pool.amount + reward)
+    pool.amount
+        .checked_add(reward)
+        .ok_or(FarmError::ArithmeticOverflow)
+}
+
+// ── Tests (Issue #239: arithmetic safety) ───────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn make_env() -> Env {
+        let env = Env::default();
+        env.mock_all_auths();
+        env
+    }
+
+    #[test]
+    fn test_calculate_farm_reward_matches_worked_example() {
+        // 15% APY, 100 staked, 1 full year elapsed => 15 units of reward.
+        let reward = calculate_farm_reward(100, SECONDS_IN_YEAR).unwrap();
+        assert_eq!(reward, 15);
+    }
+
+    #[test]
+    fn test_calculate_farm_reward_zero_elapsed_is_zero() {
+        assert_eq!(calculate_farm_reward(1_000_000, 0), Some(0));
+    }
+
+    #[test]
+    fn test_calculate_farm_reward_overflow_reported_not_wrapped() {
+        // i128::MAX * BASE_APY_BPS overflows the first checked_mul.
+        assert_eq!(calculate_farm_reward(i128::MAX, SECONDS_IN_YEAR), None);
+    }
+
+    proptest! {
+        /// The reward helper never panics for any amount within the whale
+        /// cap and any realistic elapsed duration, and never returns a
+        /// negative reward for a non-negative stake.
+        #[test]
+        fn farm_reward_never_panics_within_whale_cap(
+            amount in 0i128..=WHALE_CAP,
+            elapsed in 0u64..=(SECONDS_IN_YEAR * 100),
+        ) {
+            let reward = calculate_farm_reward(amount, elapsed);
+            if let Some(r) = reward {
+                prop_assert!(r >= 0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_deposit_withdraw_pool_id_increments_safely() {
+        let env = make_env();
+        let owner = Address::generate(&env);
+
+        let id1 = deposit_to_pool(env.clone(), owner.clone(), 100, 0).unwrap();
+        let id2 = deposit_to_pool(env.clone(), owner.clone(), 100, 0).unwrap();
+        assert_eq!(id2, id1 + 1);
+    }
+
+    #[test]
+    fn test_withdraw_before_lock_period_rejected() {
+        let env = make_env();
+        let owner = Address::generate(&env);
+
+        let id = deposit_to_pool(env.clone(), owner.clone(), 100, 1_000).unwrap();
+        let result = withdraw_from_pool(env.clone(), owner, id);
+        assert_eq!(result, Err(FarmError::LockNotMet));
+    }
 }


### PR DESCRIPTION
  ## Summary
  - Enable overflow-checks and replace unchecked arithmetic with checked_*/saturating_* in
  resource_minter, yield_farming, analytics, and treasure_vault
  - Apply the existing reentrancy guard to claim_yield, complete_escrow, and swap_exact_input —
  the balance-moving functions actually exposed to reentrancy via a malicious require_auth
  callback
  - Fix a privilege-escalation bug where set_admin in leaderboards/content_tools/pvp_combat let
  any caller reassign the admin at any time; it's now a one-time initializer
  - Add crafting skill trees: specializations, skill-point unlock progression, mastery output
  bonuses, and boosted rare-recipe discovery

  ## Details
  **Arithmetic safety (#239):** balance/supply credits, pool-id counters, lock-expiry timestamps,
  and yield/bonus calculations now use checked arithmetic and report `ArithmeticOverflow` instead
  of silently wrapping. Non-financial dashboard counters (analytics.rs) use saturating arithmetic
  per the issue's own guidance. Added property-based tests (proptest) for the new checked helpers.

  **Reentrancy (#238):** audited every function named in the issue. `composability_examples.rs`
  already guards its one live cross-contract call site. `dex_integration.rs`'s `auto_list_on_dex`
  no longer exists in the codebase. Added `with_guard` to `claim_yield`, `complete_escrow`, and
  `swap_exact_input`, plus tests proving a held lock rejects reentry.

  **Access control (#237):** `set_admin` in three modules only checked the *new* admin's
  signature, never the *current* admin's, allowing anyone to hijack the role at any time. It's now
  callable exactly once (mirroring the idempotent init pattern already used by
  `access_control::init_roles` and `emergency_controls::initialize_admins`). Documented in
  RBAC_PATTERN_GUIDE.md.

  **Crafting skill trees (#266):** players choose one specialization (one-time), earn skill points
  on level-up, spend them to unlock a small fixed skill tree, get a mastery output bonus every 10
  crafts of the same recipe, and get boosted rare-recipe discovery odds with a "keen eye" node
  unlocked. Untagged recipes remain unaffected/backward compatible.

  ## Test plan
  - [x] `cargo build --lib`
  - [x] `cargo test --lib` compiles clean for all touched code (pre-existing unrelated
  compile/runtime failures on `main` confirmed via `git diff main` isolation)
  - [x] New unit + property-based tests for every changed/added function

  Closes #239
  Closes #238
  Closes #237
  Closes #266
