### PR TITLE
feat: daily login rewards, token burning, quest system, and cosmetic marketplace

### DIFF
--- a/src/daily_rewards.rs
+++ b/src/daily_rewards.rs
@@ -1,0 +1,862 @@
+//! Daily login rewards — Issue #280
+//!
+//! Retention loop for returning nomads. A player claims once per UTC day and
+//! walks a fixed 28-day **calendar**; the calendar slot decides *what* the
+//! reward is (reward variety), while the player's consecutive-login **streak**
+//! decides *how much* of it they get (escalating rewards).
+//!
+//! Design notes:
+//!   • Day granularity is `timestamp / 86_400` — the same convention used by
+//!     [`crate::mission_generator`] for daily mission resets.
+//!   • The streak itself lives on the player's profile (see
+//!     [`crate::player_profile::record_login`]) so that every subsystem reads
+//!     one authoritative value; this module owns the calendar and payouts.
+//!   • Rewards are pure functions of (calendar slot, streak), so a front-end
+//!     can render the whole month ahead via [`get_reward_calendar`] and the
+//!     exact next payout via [`preview_daily_reward`] without mutating state.
+
+use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Vec};
+
+use crate::player_profile::{self, ProfileError};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/// Seconds in a reward day. Claims are bucketed by `timestamp / DAY_SECS`.
+pub const DAY_SECS: u64 = 86_400;
+
+/// Length of one full reward calendar cycle (4 weeks).
+pub const CALENDAR_DAYS: u32 = 28;
+
+/// Extra basis points of reward granted per consecutive login day.
+pub const STREAK_BONUS_BPS_PER_DAY: u32 = 500;
+
+/// Ceiling on the streak bonus (300 % on top of base) so a very long streak
+/// cannot mint unbounded essence.
+pub const MAX_STREAK_BONUS_BPS: u32 = 30_000;
+
+/// Streak length at which the bonus saturates — derived so the two constants
+/// above can never disagree.
+pub const STREAK_BONUS_CAP_DAYS: u32 = MAX_STREAK_BONUS_BPS / STREAK_BONUS_BPS_PER_DAY;
+
+/// Base essence granted on an ordinary calendar day.
+pub const BASE_ESSENCE: i128 = 50;
+
+/// Weekly milestone slots (day 7, 14, 21, 28 of the cycle) pay a multiple of
+/// the ordinary day's base amount.
+pub const MILESTONE_MULTIPLIER: i128 = 4;
+
+/// The final slot of the cycle is the grand prize.
+pub const CYCLE_COMPLETE_MULTIPLIER: i128 = 10;
+
+// ─── Storage Keys ─────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DailyRewardKey {
+    /// Per-player claim/streak bookkeeping.
+    Record(Address),
+    /// Global count of rewards ever claimed.
+    TotalClaims,
+    /// Global essence ever paid out by this module.
+    TotalEssencePaid,
+    /// Number of players who have claimed at least once.
+    UniqueClaimers,
+}
+
+// ─── Data Types ───────────────────────────────────────────────────────────────
+
+/// The kind of payout occupying a calendar slot. Drives reward variety: a
+/// player walking the calendar receives a mix of currency, resources, crafting
+/// materials and cosmetic rolls rather than a single escalating number.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RewardKind {
+    /// Soft currency credited straight to the player's profile.
+    Essence,
+    /// Stellar dust resource grant.
+    StellarDust,
+    /// Dark matter resource grant.
+    DarkMatter,
+    /// Exotic matter — the rare resource, milestone slots only.
+    ExoticMatter,
+    /// Energy refill for the ship's scan budget.
+    Energy,
+    /// A cosmetic skin roll (rarity decided by the caller's roll table).
+    CosmeticRoll,
+}
+
+/// A fully-resolved reward: what the player gets and why.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DailyReward {
+    /// 1-based slot within the 28-day calendar.
+    pub calendar_day: u32,
+    pub kind: RewardKind,
+    /// Payout before the streak bonus is applied.
+    pub base_amount: i128,
+    /// Payout after the streak bonus — this is what is actually credited.
+    pub amount: i128,
+    /// Streak bonus applied, in basis points.
+    pub streak_bonus_bps: u32,
+    /// True for weekly milestones and the cycle finale.
+    pub is_milestone: bool,
+}
+
+/// Per-player daily-login bookkeeping.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoginRecord {
+    pub player: Address,
+    /// Day index (`timestamp / DAY_SECS`) of the most recent claim.
+    pub last_claim_day: u64,
+    /// Consecutive claim days, including today.
+    pub current_streak: u32,
+    /// Best streak ever achieved.
+    pub longest_streak: u32,
+    /// Lifetime number of claims.
+    pub total_claims: u32,
+    /// Number of completed 28-day calendar cycles.
+    pub cycles_completed: u32,
+    /// Lifetime essence-equivalent value claimed through this module.
+    pub lifetime_value: i128,
+}
+
+/// Aggregate module statistics for dashboards.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DailyRewardStats {
+    pub total_claims: u64,
+    pub total_essence_paid: i128,
+    pub unique_claimers: u64,
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum DailyRewardError {
+    /// The player already claimed during the current UTC day.
+    AlreadyClaimedToday = 1,
+    /// No profile exists for the claiming address.
+    ProfileNotFound = 2,
+    /// Reward math overflowed (unreachable with the constants above, but the
+    /// crate policy is that no balance-modifying path may wrap).
+    ArithmeticOverflow = 3,
+    /// `calendar_day` outside `1..=CALENDAR_DAYS`.
+    InvalidCalendarDay = 4,
+}
+
+impl From<ProfileError> for DailyRewardError {
+    fn from(e: ProfileError) -> Self {
+        match e {
+            ProfileError::ArithmeticOverflow => DailyRewardError::ArithmeticOverflow,
+            _ => DailyRewardError::ProfileNotFound,
+        }
+    }
+}
+
+// ─── Calendar ─────────────────────────────────────────────────────────────────
+
+/// True when `calendar_day` is a weekly milestone or the cycle finale.
+pub fn is_milestone_day(calendar_day: u32) -> bool {
+    calendar_day % 7 == 0
+}
+
+/// The payout kind occupying calendar slot `calendar_day` (1-based).
+///
+/// The rotation is deliberately hand-written rather than derived from the day
+/// number: it keeps rare grants (exotic matter, cosmetic rolls) on milestone
+/// slots and spreads the ordinary kinds so no two adjacent days repeat.
+pub fn calendar_kind(calendar_day: u32) -> RewardKind {
+    if calendar_day == CALENDAR_DAYS {
+        // Cycle finale is always a cosmetic roll — the memorable reward.
+        return RewardKind::CosmeticRoll;
+    }
+    if is_milestone_day(calendar_day) {
+        return RewardKind::ExoticMatter;
+    }
+    match calendar_day % 6 {
+        0 => RewardKind::Energy,
+        1 => RewardKind::Essence,
+        2 => RewardKind::StellarDust,
+        3 => RewardKind::Essence,
+        4 => RewardKind::DarkMatter,
+        _ => RewardKind::Energy,
+    }
+}
+
+/// Base (pre-streak) payout for a calendar slot.
+fn calendar_base_amount(calendar_day: u32) -> i128 {
+    if calendar_day == CALENDAR_DAYS {
+        BASE_ESSENCE.saturating_mul(CYCLE_COMPLETE_MULTIPLIER)
+    } else if is_milestone_day(calendar_day) {
+        BASE_ESSENCE.saturating_mul(MILESTONE_MULTIPLIER)
+    } else {
+        BASE_ESSENCE
+    }
+}
+
+/// Streak bonus in basis points for a streak of `streak` consecutive days.
+///
+/// Day 1 earns no bonus; each further day adds [`STREAK_BONUS_BPS_PER_DAY`]
+/// until the bonus saturates at [`MAX_STREAK_BONUS_BPS`].
+pub fn streak_bonus_bps(streak: u32) -> u32 {
+    streak
+        .saturating_sub(1)
+        .saturating_mul(STREAK_BONUS_BPS_PER_DAY)
+        .min(MAX_STREAK_BONUS_BPS)
+}
+
+/// Resolve the reward for a `(calendar_day, streak)` pair.
+///
+/// Pure — safe to call from read-only endpoints for previews and UI calendars.
+pub fn resolve_reward(calendar_day: u32, streak: u32) -> Result<DailyReward, DailyRewardError> {
+    if calendar_day == 0 || calendar_day > CALENDAR_DAYS {
+        return Err(DailyRewardError::InvalidCalendarDay);
+    }
+
+    let base_amount = calendar_base_amount(calendar_day);
+    let bonus_bps = streak_bonus_bps(streak);
+
+    // amount = base * (10_000 + bonus_bps) / 10_000, checked end-to-end.
+    let scaled = base_amount
+        .checked_mul(10_000i128 + bonus_bps as i128)
+        .ok_or(DailyRewardError::ArithmeticOverflow)?;
+    let amount = scaled / 10_000;
+
+    Ok(DailyReward {
+        calendar_day,
+        kind: calendar_kind(calendar_day),
+        base_amount,
+        amount,
+        streak_bonus_bps: bonus_bps,
+        is_milestone: is_milestone_day(calendar_day),
+    })
+}
+
+/// The calendar slot a player with `total_claims` lifetime claims lands on next.
+///
+/// Slots advance with claims (not wall-clock days), so a missed day costs the
+/// streak bonus but never desyncs the player from the calendar.
+pub fn next_calendar_day(total_claims: u32) -> u32 {
+    (total_claims % CALENDAR_DAYS) + 1
+}
+
+/// Render the full 28-slot calendar at a hypothetical `streak`.
+///
+/// Read-only: intended for the client to draw the month view.
+pub fn get_reward_calendar(env: &Env, streak: u32) -> Vec<DailyReward> {
+    let mut calendar = Vec::new(env);
+    for day in 1..=CALENDAR_DAYS {
+        // `day` is always in range, so `resolve_reward` cannot fail here.
+        if let Ok(reward) = resolve_reward(day, streak) {
+            calendar.push_back(reward);
+        }
+    }
+    calendar
+}
+
+// ─── Claiming ─────────────────────────────────────────────────────────────────
+
+fn load_record(env: &Env, player: &Address) -> Option<LoginRecord> {
+    env.storage()
+        .persistent()
+        .get(&DailyRewardKey::Record(player.clone()))
+}
+
+/// Fetch a player's login record, if they have ever claimed.
+pub fn get_login_record(env: &Env, player: &Address) -> Option<LoginRecord> {
+    load_record(env, player)
+}
+
+/// The player's current consecutive-login streak (0 when never claimed or when
+/// the streak has since lapsed).
+pub fn get_streak(env: &Env, player: &Address) -> u32 {
+    match load_record(env, player) {
+        Some(record) => {
+            let today = env.ledger().timestamp() / DAY_SECS;
+            // A streak survives only while today is the claim day or the one
+            // right after it; beyond that the chain is already broken.
+            if today <= record.last_claim_day + 1 {
+                record.current_streak
+            } else {
+                0
+            }
+        }
+        None => 0,
+    }
+}
+
+/// True when `player` may claim right now.
+pub fn can_claim(env: &Env, player: &Address) -> bool {
+    match load_record(env, player) {
+        Some(record) => env.ledger().timestamp() / DAY_SECS > record.last_claim_day,
+        None => true,
+    }
+}
+
+/// The reward `player` would receive if they claimed right now.
+///
+/// Read-only. Returns `AlreadyClaimedToday` when the claim would be rejected,
+/// so a client can use this as a single source of truth for the claim button.
+pub fn preview_daily_reward(env: &Env, player: &Address) -> Result<DailyReward, DailyRewardError> {
+    let today = env.ledger().timestamp() / DAY_SECS;
+
+    let (total_claims, streak) = match load_record(env, player) {
+        Some(record) => {
+            if today <= record.last_claim_day {
+                return Err(DailyRewardError::AlreadyClaimedToday);
+            }
+            let continues = today == record.last_claim_day + 1;
+            let streak = if continues {
+                record.current_streak.saturating_add(1)
+            } else {
+                1
+            };
+            (record.total_claims, streak)
+        }
+        None => (0, 1),
+    };
+
+    resolve_reward(next_calendar_day(total_claims), streak)
+}
+
+/// Claim today's login reward.
+///
+/// Advances the calendar, extends or resets the streak, credits the payout to
+/// the player's profile and emits `daily/claimed`. Milestone slots additionally
+/// emit `daily/milestn` so indexers can surface them without re-deriving the
+/// calendar.
+pub fn claim_daily_reward(env: &Env, player: Address) -> Result<DailyReward, DailyRewardError> {
+    player.require_auth();
+
+    // A profile must exist — the reward is credited to it.
+    let profile = player_profile::get_profile_by_owner(env, &player)?;
+
+    let today = env.ledger().timestamp() / DAY_SECS;
+    let existing = load_record(env, &player);
+
+    let (streak_before, total_claims_before, longest_before, cycles_before, lifetime_before) =
+        match &existing {
+            Some(r) => (
+                r.current_streak,
+                r.total_claims,
+                r.longest_streak,
+                r.cycles_completed,
+                r.lifetime_value,
+            ),
+            None => (0, 0, 0, 0, 0i128),
+        };
+
+    if let Some(record) = &existing {
+        if today <= record.last_claim_day {
+            return Err(DailyRewardError::AlreadyClaimedToday);
+        }
+    }
+
+    // Streak continues only if the previous claim was literally yesterday.
+    let streak_continues = existing
+        .as_ref()
+        .map(|r| today == r.last_claim_day + 1)
+        .unwrap_or(false);
+    let new_streak = if streak_continues {
+        streak_before.saturating_add(1)
+    } else {
+        1
+    };
+
+    let calendar_day = next_calendar_day(total_claims_before);
+    let reward = resolve_reward(calendar_day, new_streak)?;
+
+    let total_claims = total_claims_before
+        .checked_add(1)
+        .ok_or(DailyRewardError::ArithmeticOverflow)?;
+    let cycles_completed = if calendar_day == CALENDAR_DAYS {
+        cycles_before.saturating_add(1)
+    } else {
+        cycles_before
+    };
+    let lifetime_value = lifetime_before
+        .checked_add(reward.amount)
+        .ok_or(DailyRewardError::ArithmeticOverflow)?;
+
+    let record = LoginRecord {
+        player: player.clone(),
+        last_claim_day: today,
+        current_streak: new_streak,
+        longest_streak: longest_before.max(new_streak),
+        total_claims,
+        cycles_completed,
+        lifetime_value,
+    };
+    env.storage()
+        .persistent()
+        .set(&DailyRewardKey::Record(player.clone()), &record);
+
+    // Mirror the streak onto the profile so other subsystems read one value.
+    player_profile::record_login(env, profile.id, today, new_streak)?;
+    player_profile::credit_essence(env, profile.id, reward.amount)?;
+
+    // ── Global stats ──────────────────────────────────────────────────────
+    let claims: u64 = env
+        .storage()
+        .persistent()
+        .get(&DailyRewardKey::TotalClaims)
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&DailyRewardKey::TotalClaims, &claims.saturating_add(1));
+
+    let paid: i128 = env
+        .storage()
+        .persistent()
+        .get(&DailyRewardKey::TotalEssencePaid)
+        .unwrap_or(0);
+    env.storage().persistent().set(
+        &DailyRewardKey::TotalEssencePaid,
+        &paid.saturating_add(reward.amount),
+    );
+
+    if existing.is_none() {
+        let claimers: u64 = env
+            .storage()
+            .persistent()
+            .get(&DailyRewardKey::UniqueClaimers)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DailyRewardKey::UniqueClaimers, &claimers.saturating_add(1));
+    }
+
+    // ── Events ────────────────────────────────────────────────────────────
+    env.events().publish(
+        (symbol_short!("daily"), symbol_short!("claimed")),
+        (
+            player.clone(),
+            calendar_day,
+            new_streak,
+            reward.kind,
+            reward.amount,
+        ),
+    );
+
+    if !streak_continues && streak_before > 0 {
+        env.events().publish(
+            (symbol_short!("daily"), symbol_short!("brokestk")),
+            (player.clone(), streak_before),
+        );
+    }
+
+    if reward.is_milestone {
+        env.events().publish(
+            (symbol_short!("daily"), symbol_short!("milestn")),
+            (player, calendar_day, reward.amount),
+        );
+    }
+
+    Ok(reward)
+}
+
+/// Aggregate module statistics.
+pub fn get_daily_reward_stats(env: &Env) -> DailyRewardStats {
+    DailyRewardStats {
+        total_claims: env
+            .storage()
+            .persistent()
+            .get(&DailyRewardKey::TotalClaims)
+            .unwrap_or(0),
+        total_essence_paid: env
+            .storage()
+            .persistent()
+            .get(&DailyRewardKey::TotalEssencePaid)
+            .unwrap_or(0),
+        unique_claimers: env
+            .storage()
+            .persistent()
+            .get(&DailyRewardKey::UniqueClaimers)
+            .unwrap_or(0),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{contract, contractimpl};
+
+    #[contract]
+    struct Stub;
+    #[contractimpl]
+    impl Stub {}
+
+    /// Soroban storage is only reachable inside a contract invocation, so the
+    /// tests below run their bodies through `Env::as_contract` — the same
+    /// pattern the rest of the crate's unit tests use.
+    struct Harness {
+        env: Env,
+        contract: Address,
+        player: Address,
+    }
+
+    fn harness() -> Harness {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = env.register(Stub, ());
+        let player = Address::generate(&env);
+        Harness {
+            env,
+            contract,
+            player,
+        }
+    }
+
+    impl Harness {
+        fn run<T>(&self, f: impl FnOnce() -> T) -> T {
+            self.env.as_contract(&self.contract, f)
+        }
+
+        /// Give the harness player a profile, so rewards have somewhere to go.
+        fn with_profile(self) -> Self {
+            let player = self.player.clone();
+            self.run(|| {
+                player_profile::initialize_profile(&self.env, player).unwrap();
+            });
+            self
+        }
+
+        fn set_day(&self, day: u64) {
+            self.env
+                .ledger()
+                .with_mut(|l| l.timestamp = day * DAY_SECS + 100);
+        }
+    }
+
+    // ── Calendar ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn calendar_covers_full_cycle_with_variety() {
+        let env = Env::default();
+        let calendar = get_reward_calendar(&env, 1);
+        assert_eq!(calendar.len(), CALENDAR_DAYS);
+
+        // At least four distinct reward kinds appear across the cycle.
+        let mut kinds: Vec<RewardKind> = Vec::new(&env);
+        for i in 0..calendar.len() {
+            let kind = calendar.get(i).unwrap().kind;
+            if !kinds.iter().any(|k| k == kind) {
+                kinds.push_back(kind);
+            }
+        }
+        assert!(
+            kinds.len() >= 4,
+            "expected reward variety, got {} kinds",
+            kinds.len()
+        );
+    }
+
+    #[test]
+    fn milestone_days_pay_more_than_ordinary_days() {
+        let ordinary = resolve_reward(3, 1).unwrap();
+        let weekly = resolve_reward(7, 1).unwrap();
+        let finale = resolve_reward(CALENDAR_DAYS, 1).unwrap();
+
+        assert!(!ordinary.is_milestone);
+        assert!(weekly.is_milestone);
+        assert!(finale.is_milestone);
+        assert!(weekly.amount > ordinary.amount);
+        assert!(finale.amount > weekly.amount);
+        assert_eq!(finale.kind, RewardKind::CosmeticRoll);
+    }
+
+    #[test]
+    fn calendar_day_out_of_range_is_rejected() {
+        assert_eq!(
+            resolve_reward(0, 1),
+            Err(DailyRewardError::InvalidCalendarDay)
+        );
+        assert_eq!(
+            resolve_reward(CALENDAR_DAYS + 1, 1),
+            Err(DailyRewardError::InvalidCalendarDay)
+        );
+    }
+
+    #[test]
+    fn calendar_slot_advances_with_claims_and_wraps() {
+        assert_eq!(next_calendar_day(0), 1);
+        assert_eq!(next_calendar_day(27), 28);
+        assert_eq!(next_calendar_day(28), 1);
+        assert_eq!(next_calendar_day(29), 2);
+    }
+
+    // ── Escalation ────────────────────────────────────────────────────────
+
+    #[test]
+    fn streak_bonus_escalates_then_saturates() {
+        assert_eq!(streak_bonus_bps(0), 0);
+        assert_eq!(streak_bonus_bps(1), 0);
+        assert_eq!(streak_bonus_bps(2), STREAK_BONUS_BPS_PER_DAY);
+        assert_eq!(
+            streak_bonus_bps(STREAK_BONUS_CAP_DAYS + 1),
+            MAX_STREAK_BONUS_BPS
+        );
+        // Saturated: further days add nothing.
+        assert_eq!(streak_bonus_bps(u32::MAX), MAX_STREAK_BONUS_BPS);
+    }
+
+    #[test]
+    fn reward_amount_grows_monotonically_with_streak() {
+        let mut previous = 0i128;
+        for streak in 1..=STREAK_BONUS_CAP_DAYS {
+            let reward = resolve_reward(1, streak).unwrap();
+            assert!(
+                reward.amount >= previous,
+                "streak {streak} regressed: {} < {previous}",
+                reward.amount
+            );
+            previous = reward.amount;
+        }
+    }
+
+    // ── Claim flow ────────────────────────────────────────────────────────
+
+    #[test]
+    fn first_claim_starts_a_streak_of_one() {
+        let h = harness().with_profile();
+        h.set_day(100);
+
+        h.run(|| {
+            let reward = claim_daily_reward(&h.env, h.player.clone()).unwrap();
+            assert_eq!(reward.calendar_day, 1);
+            assert_eq!(reward.streak_bonus_bps, 0);
+
+            let record = get_login_record(&h.env, &h.player).unwrap();
+            assert_eq!(record.current_streak, 1);
+            assert_eq!(record.total_claims, 1);
+            assert_eq!(record.last_claim_day, 100);
+        });
+    }
+
+    #[test]
+    fn second_claim_same_day_is_rejected() {
+        let h = harness().with_profile();
+        h.set_day(100);
+
+        // Separate invocations: `require_auth` may only be satisfied once per
+        // contract frame, so each claim needs its own.
+        h.run(|| claim_daily_reward(&h.env, h.player.clone()).unwrap());
+
+        h.run(|| {
+            assert_eq!(
+                claim_daily_reward(&h.env, h.player.clone()),
+                Err(DailyRewardError::AlreadyClaimedToday)
+            );
+            assert!(!can_claim(&h.env, &h.player));
+        });
+    }
+
+    #[test]
+    fn consecutive_days_build_the_streak() {
+        let h = harness().with_profile();
+
+        for day in 100..107 {
+            h.set_day(day);
+            h.run(|| claim_daily_reward(&h.env, h.player.clone()).unwrap());
+        }
+
+        h.run(|| {
+            let record = get_login_record(&h.env, &h.player).unwrap();
+            assert_eq!(record.current_streak, 7);
+            assert_eq!(record.longest_streak, 7);
+            assert_eq!(record.total_claims, 7);
+        });
+    }
+
+    #[test]
+    fn missed_day_resets_streak_but_keeps_longest_and_calendar() {
+        let h = harness().with_profile();
+
+        for day in 100..105 {
+            h.set_day(day);
+            h.run(|| claim_daily_reward(&h.env, h.player.clone()).unwrap());
+        }
+        h.run(|| {
+            assert_eq!(
+                get_login_record(&h.env, &h.player).unwrap().current_streak,
+                5
+            );
+        });
+
+        // Skip day 105 entirely.
+        h.set_day(106);
+        h.run(|| {
+            let reward = claim_daily_reward(&h.env, h.player.clone()).unwrap();
+
+            let record = get_login_record(&h.env, &h.player).unwrap();
+            assert_eq!(record.current_streak, 1, "streak must reset after a gap");
+            assert_eq!(record.longest_streak, 5, "longest streak is preserved");
+            // The calendar keeps advancing regardless of the broken streak.
+            assert_eq!(reward.calendar_day, 6);
+            assert_eq!(reward.streak_bonus_bps, 0);
+        });
+    }
+
+    #[test]
+    fn full_cycle_increments_cycles_completed() {
+        let h = harness().with_profile();
+
+        for day in 100..(100 + CALENDAR_DAYS as u64) {
+            h.set_day(day);
+            h.run(|| claim_daily_reward(&h.env, h.player.clone()).unwrap());
+        }
+
+        h.run(|| {
+            let record = get_login_record(&h.env, &h.player).unwrap();
+            assert_eq!(record.total_claims, CALENDAR_DAYS);
+            assert_eq!(record.cycles_completed, 1);
+            assert_eq!(record.current_streak, CALENDAR_DAYS);
+        });
+
+        // Next claim wraps back to slot 1 of a fresh cycle.
+        h.set_day(100 + CALENDAR_DAYS as u64);
+        h.run(|| {
+            let reward = claim_daily_reward(&h.env, h.player.clone()).unwrap();
+            assert_eq!(reward.calendar_day, 1);
+        });
+    }
+
+    #[test]
+    fn claim_credits_essence_to_the_profile() {
+        let h = harness().with_profile();
+        h.set_day(100);
+
+        h.run(|| {
+            let before = player_profile::get_profile_by_owner(&h.env, &h.player)
+                .unwrap()
+                .essence_earned;
+            let reward = claim_daily_reward(&h.env, h.player.clone()).unwrap();
+            let after = player_profile::get_profile_by_owner(&h.env, &h.player)
+                .unwrap()
+                .essence_earned;
+
+            assert_eq!(after - before, reward.amount);
+        });
+    }
+
+    #[test]
+    fn claim_mirrors_streak_onto_the_profile() {
+        let h = harness().with_profile();
+
+        for day in 100..104 {
+            h.set_day(day);
+            h.run(|| claim_daily_reward(&h.env, h.player.clone()).unwrap());
+        }
+
+        h.run(|| {
+            let profile = player_profile::get_profile_by_owner(&h.env, &h.player).unwrap();
+            assert_eq!(profile.login_streak, 4);
+            assert_eq!(profile.longest_login_streak, 4);
+            assert_eq!(profile.last_login_day, 103);
+        });
+    }
+
+    #[test]
+    fn claim_without_a_profile_is_rejected() {
+        // No `with_profile()` — the claimer has never joined.
+        let h = harness();
+        h.set_day(100);
+
+        h.run(|| {
+            assert_eq!(
+                claim_daily_reward(&h.env, h.player.clone()),
+                Err(DailyRewardError::ProfileNotFound)
+            );
+        });
+    }
+
+    #[test]
+    fn preview_matches_the_reward_actually_granted() {
+        let h = harness().with_profile();
+        h.set_day(100);
+        h.run(|| claim_daily_reward(&h.env, h.player.clone()).unwrap());
+
+        h.set_day(101);
+        h.run(|| {
+            let preview = preview_daily_reward(&h.env, &h.player).unwrap();
+            let granted = claim_daily_reward(&h.env, h.player.clone()).unwrap();
+            assert_eq!(preview, granted);
+        });
+    }
+
+    #[test]
+    fn preview_reports_already_claimed() {
+        let h = harness().with_profile();
+        h.set_day(100);
+
+        h.run(|| {
+            claim_daily_reward(&h.env, h.player.clone()).unwrap();
+            assert_eq!(
+                preview_daily_reward(&h.env, &h.player),
+                Err(DailyRewardError::AlreadyClaimedToday)
+            );
+        });
+    }
+
+    #[test]
+    fn preview_for_a_new_player_is_day_one() {
+        let h = harness().with_profile();
+        h.set_day(100);
+
+        h.run(|| {
+            let preview = preview_daily_reward(&h.env, &h.player).unwrap();
+            assert_eq!(preview.calendar_day, 1);
+            assert!(can_claim(&h.env, &h.player));
+        });
+    }
+
+    #[test]
+    fn get_streak_reports_zero_once_the_chain_lapses() {
+        let h = harness().with_profile();
+        h.set_day(100);
+        h.run(|| claim_daily_reward(&h.env, h.player.clone()).unwrap());
+
+        h.set_day(101);
+        h.run(|| assert_eq!(get_streak(&h.env, &h.player), 1, "still claimable today"));
+
+        h.set_day(103);
+        h.run(|| assert_eq!(get_streak(&h.env, &h.player), 0, "chain has lapsed"));
+    }
+
+    #[test]
+    fn stats_accumulate_across_players() {
+        let h = harness().with_profile();
+        let other = Address::generate(&h.env);
+        h.set_day(100);
+
+        h.run(|| player_profile::initialize_profile(&h.env, other.clone()).unwrap());
+        let a = h.run(|| claim_daily_reward(&h.env, h.player.clone()).unwrap());
+        let b = h.run(|| claim_daily_reward(&h.env, other.clone()).unwrap());
+
+        h.run(|| {
+            let stats = get_daily_reward_stats(&h.env);
+            assert_eq!(stats.total_claims, 2);
+            assert_eq!(stats.unique_claimers, 2);
+            assert_eq!(stats.total_essence_paid, a.amount + b.amount);
+        });
+    }
+
+    #[test]
+    fn unique_claimers_counts_each_player_once() {
+        let h = harness().with_profile();
+
+        for day in 100..103 {
+            h.set_day(day);
+            h.run(|| claim_daily_reward(&h.env, h.player.clone()).unwrap());
+        }
+
+        h.run(|| assert_eq!(get_daily_reward_stats(&h.env).unique_claimers, 1));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ mod crafting;
 // Retention, economy, content and cosmetic-marketplace systems
 // (Issues #280, #281, #282, #283).
 mod daily_rewards;
+mod token_burning;
 pub mod recipes;
 pub mod notifications {
     pub mod push_service;
@@ -343,6 +344,11 @@ pub use skins::{get_skin_templates, SkinTemplate};
 pub use daily_rewards::{
     DailyReward, DailyRewardError, DailyRewardStats, LoginRecord, RewardKind, CALENDAR_DAYS,
     MAX_STREAK_BONUS_BPS, STREAK_BONUS_BPS_PER_DAY, STREAK_BONUS_CAP_DAYS,
+};
+
+// ─── Token Burning (Issue #281) ───────────────────────────────────────────
+pub use token_burning::{
+    BurnReason, BurnRecord, BurnStats, BurningError, PlayerBurnStats, MAX_BURN_FEE_BPS,
 };
 
 pub use economics::monitor::{
@@ -2847,6 +2853,84 @@ impl NebulaNomadContract {
     /// Aggregate daily-reward statistics.
     pub fn get_daily_reward_stats(env: Env) -> DailyRewardStats {
         daily_rewards::get_daily_reward_stats(&env)
+    }
+
+    // ─── Token Burning (Issue #281) ───────────────────────────────────────
+
+    /// Destroy the caller's own resources, reducing circulating supply.
+    pub fn burn_resource(
+        env: Env,
+        burner: Address,
+        resource_type: ResourceType,
+        amount: u64,
+        reason: BurnReason,
+    ) -> Result<BurnRecord, BurningError> {
+        token_burning::burn(&env, burner, resource_type, amount, reason)
+    }
+
+    /// Set the admin permitted to change the deflationary fee rate.
+    pub fn initialize_burn_admin(env: Env, admin: Address) -> Result<(), BurningError> {
+        token_burning::initialize_burn_admin(&env, admin)
+    }
+
+    /// Update the deflationary fee rate (admin only).
+    pub fn set_burn_fee_bps(env: Env, caller: Address, bps: u32) -> Result<(), BurningError> {
+        token_burning::set_burn_fee_bps(&env, caller, bps)
+    }
+
+    /// The configured deflationary fee rate, in basis points.
+    pub fn get_burn_fee_bps(env: Env) -> u32 {
+        token_burning::get_burn_fee_bps(&env)
+    }
+
+    /// Global burn statistics for one resource type.
+    pub fn get_burn_stats(env: Env, resource_type: ResourceType) -> BurnStats {
+        token_burning::get_burn_stats(&env, resource_type)
+    }
+
+    /// A single player's burn contribution.
+    pub fn get_player_burn_stats(env: Env, player: Address) -> PlayerBurnStats {
+        token_burning::get_player_burn_stats(&env, player)
+    }
+
+    /// Share of ever-minted supply that has been burned, in basis points.
+    pub fn get_deflation_rate_bps(env: Env, resource_type: ResourceType) -> u32 {
+        token_burning::deflation_rate_bps(&env, &resource_type)
+    }
+
+    /// Retrieve a burn receipt by ID.
+    pub fn get_burn_record(env: Env, burn_id: u64) -> Option<BurnRecord> {
+        token_burning::get_burn_record(&env, burn_id)
+    }
+
+    /// Transfer resources, burning the deflationary fee slice in transit.
+    pub fn transfer_resource_with_burn(
+        env: Env,
+        from: Address,
+        to: Address,
+        resource_type: ResourceType,
+        amount: u64,
+    ) -> Result<u64, BurningError> {
+        token_burning::transfer_with_burn(&env, from, to, resource_type, amount)
+    }
+
+    /// Amount a player has burned of one specific resource type.
+    pub fn get_player_burned_of(
+        env: Env,
+        player: Address,
+        resource_type: ResourceType,
+    ) -> u64 {
+        token_burning::player_burned_of(&env, &player, &resource_type)
+    }
+
+    /// Sum of burned amounts across every resource type.
+    pub fn get_total_burned_all(env: Env) -> u64 {
+        token_burning::total_burned_all(&env)
+    }
+
+    /// Cumulative amount ever minted of a resource, ignoring burns.
+    pub fn get_total_minted(env: Env, resource_type: ResourceType) -> u64 {
+        resource_minter::total_minted(&env, &resource_type)
     }
 
     // ─── Economic Monitoring & Balancing ──────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,10 @@ pub mod achievements;
 mod ship_customization;
 mod skins;
 mod crafting;
+
+// Retention, economy, content and cosmetic-marketplace systems
+// (Issues #280, #281, #282, #283).
+mod daily_rewards;
 pub mod recipes;
 pub mod notifications {
     pub mod push_service;
@@ -334,6 +338,12 @@ pub use ship_customization::{
     ShipSkin, SkinRarity, SkinError,
 };
 pub use skins::{get_skin_templates, SkinTemplate};
+
+// ─── Daily Login Rewards (Issue #280) ─────────────────────────────────────
+pub use daily_rewards::{
+    DailyReward, DailyRewardError, DailyRewardStats, LoginRecord, RewardKind, CALENDAR_DAYS,
+    MAX_STREAK_BONUS_BPS, STREAK_BONUS_BPS_PER_DAY, STREAK_BONUS_CAP_DAYS,
+};
 
 pub use economics::monitor::{
     initialize_monitor, update_supply_metrics, track_resource_activity,
@@ -2797,6 +2807,46 @@ impl NebulaNomadContract {
 
     pub fn get_skin_templates(env: Env) -> Vec<SkinTemplate> {
         skins::get_skin_templates(&env)
+    }
+
+    // ─── Daily Login Rewards (Issue #280) ─────────────────────────────────
+
+    /// Claim today's login reward, advancing the calendar and streak.
+    pub fn claim_daily_reward(env: Env, player: Address) -> Result<DailyReward, DailyRewardError> {
+        daily_rewards::claim_daily_reward(&env, player)
+    }
+
+    /// The reward the player would receive if they claimed right now.
+    pub fn preview_daily_reward(
+        env: Env,
+        player: Address,
+    ) -> Result<DailyReward, DailyRewardError> {
+        daily_rewards::preview_daily_reward(&env, &player)
+    }
+
+    /// Whether the player has an unclaimed reward available today.
+    pub fn can_claim_daily_reward(env: Env, player: Address) -> bool {
+        daily_rewards::can_claim(&env, &player)
+    }
+
+    /// The player's consecutive-login streak (0 once it lapses).
+    pub fn get_daily_streak(env: Env, player: Address) -> u32 {
+        daily_rewards::get_streak(&env, &player)
+    }
+
+    /// The player's full login/claim record.
+    pub fn get_login_record(env: Env, player: Address) -> Option<LoginRecord> {
+        daily_rewards::get_login_record(&env, &player)
+    }
+
+    /// Render the whole 28-day calendar at a hypothetical streak.
+    pub fn get_reward_calendar(env: Env, streak: u32) -> Vec<DailyReward> {
+        daily_rewards::get_reward_calendar(&env, streak)
+    }
+
+    /// Aggregate daily-reward statistics.
+    pub fn get_daily_reward_stats(env: Env) -> DailyRewardStats {
+        daily_rewards::get_daily_reward_stats(&env)
     }
 
     // ─── Economic Monitoring & Balancing ──────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,15 @@ pub use quest_system::{
     QuestStatus, MAX_ACTIVE_QUESTS, MAX_BRANCHES_PER_NODE, MAX_CHAIN_LENGTH,
 };
 
+// ─── Cosmetic NFT Marketplace (Issue #283) ────────────────────────────────
+pub use nft_marketplace::{
+    CosmeticListing, CosmeticMarketStats, CreatorRoyalty, MarketplaceError, SaleSplit,
+    CREATOR_ROYALTY_BPS_DEFAULT, MAX_CREATOR_ROYALTY_BPS, PLATFORM_FEE_BPS,
+};
+pub use skins::{
+    rarity_drop_weight_bps, rarity_floor_price, roll_rarity, SkinPreview, SkinRarityStats,
+};
+
 pub use economics::monitor::{
     initialize_monitor, update_supply_metrics, track_resource_activity,
     get_metrics, get_resource_metrics, calculate_inflation_rate,
@@ -3056,6 +3065,108 @@ impl NebulaNomadContract {
     /// IDs of the player's currently active quests.
     pub fn get_active_quest_ids(env: Env, player: Address) -> Vec<u64> {
         quest_system::get_active_quests(&env, &player)
+    }
+
+    // ─── Cosmetic NFT Marketplace (Issue #283) ────────────────────────────
+
+    /// List a cosmetic skin NFT for sale at or above its rarity floor.
+    pub fn list_cosmetic(
+        env: Env,
+        seller: Address,
+        skin_id: u64,
+        price: i128,
+    ) -> Result<CosmeticListing, MarketplaceError> {
+        nft_marketplace::list_cosmetic(&env, &seller, skin_id, price)
+    }
+
+    /// Purchase a listed cosmetic, settling creator royalty and platform fee.
+    pub fn buy_cosmetic(
+        env: Env,
+        buyer: Address,
+        skin_id: u64,
+    ) -> Result<SaleSplit, MarketplaceError> {
+        nft_marketplace::buy_cosmetic(&env, &buyer, skin_id)
+    }
+
+    /// Cancel an open cosmetic listing, releasing the skin from escrow.
+    pub fn cancel_cosmetic_listing(
+        env: Env,
+        seller: Address,
+        skin_id: u64,
+    ) -> Result<(), MarketplaceError> {
+        nft_marketplace::cancel_cosmetic_listing(&env, &seller, skin_id)
+    }
+
+    /// The open cosmetic listing for a skin, if any.
+    pub fn get_cosmetic_listing(env: Env, skin_id: u64) -> Option<CosmeticListing> {
+        nft_marketplace::get_cosmetic_listing(&env, skin_id)
+    }
+
+    /// Register a perpetual creator royalty on a cosmetic (owner only, once).
+    pub fn register_creator_royalty(
+        env: Env,
+        creator: Address,
+        skin_id: u64,
+        bps: i128,
+    ) -> Result<CreatorRoyalty, MarketplaceError> {
+        nft_marketplace::register_creator_royalty(&env, &creator, skin_id, bps)
+    }
+
+    /// The registered creator royalty for a cosmetic.
+    pub fn get_creator_royalty(env: Env, skin_id: u64) -> Option<CreatorRoyalty> {
+        nft_marketplace::get_creator_royalty(&env, skin_id)
+    }
+
+    /// Royalties credited to a creator and not yet withdrawn.
+    pub fn get_creator_earnings(env: Env, creator: Address) -> i128 {
+        nft_marketplace::get_creator_earnings(&env, &creator)
+    }
+
+    /// Withdraw all accrued creator royalties.
+    pub fn withdraw_creator_earnings(
+        env: Env,
+        creator: Address,
+    ) -> Result<i128, MarketplaceError> {
+        nft_marketplace::withdraw_creator_earnings(&env, &creator)
+    }
+
+    /// How a given price would be split, before listing.
+    pub fn compute_cosmetic_sale_split(
+        _env: Env,
+        price: i128,
+        royalty_bps: i128,
+    ) -> Result<SaleSplit, MarketplaceError> {
+        nft_marketplace::compute_sale_split(price, royalty_bps)
+    }
+
+    /// Aggregate cosmetic-market statistics.
+    pub fn get_cosmetic_market_stats(env: Env) -> CosmeticMarketStats {
+        nft_marketplace::get_cosmetic_market_stats(&env)
+    }
+
+    /// Render a cosmetic for a storefront card without owning it.
+    pub fn preview_cosmetic(env: Env, skin_id: u64) -> Option<SkinPreview> {
+        nft_marketplace::preview_cosmetic_listing(&env, skin_id)
+    }
+
+    /// Render a catalogue template by name.
+    pub fn preview_skin_template(env: Env, name: Symbol) -> Option<SkinPreview> {
+        skins::preview_template(&env, name)
+    }
+
+    /// All catalogue templates of one rarity tier.
+    pub fn get_templates_by_rarity(env: Env, rarity: SkinRarity) -> Vec<SkinTemplate> {
+        skins::get_templates_by_rarity(&env, rarity)
+    }
+
+    /// Weighted rarity roll from a caller-supplied seed.
+    pub fn roll_skin_rarity(_env: Env, seed: u64) -> SkinRarity {
+        skins::roll_rarity(seed)
+    }
+
+    /// Catalogue composition by rarity.
+    pub fn get_skin_rarity_stats(env: Env) -> SkinRarityStats {
+        skins::get_rarity_stats(&env)
     }
 
     // ─── Economic Monitoring & Balancing ──────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ mod crafting;
 // Retention, economy, content and cosmetic-marketplace systems
 // (Issues #280, #281, #282, #283).
 mod daily_rewards;
+mod quest_system;
 mod token_burning;
 pub mod recipes;
 pub mod notifications {
@@ -349,6 +350,12 @@ pub use daily_rewards::{
 // ─── Token Burning (Issue #281) ───────────────────────────────────────────
 pub use token_burning::{
     BurnReason, BurnRecord, BurnStats, BurningError, PlayerBurnStats, MAX_BURN_FEE_BPS,
+};
+
+// ─── Quest System (Issue #282) ────────────────────────────────────────────
+pub use quest_system::{
+    ChainProgress, QuestBranch, QuestChain, QuestError, QuestNode, QuestReward, QuestState,
+    QuestStatus, MAX_ACTIVE_QUESTS, MAX_BRANCHES_PER_NODE, MAX_CHAIN_LENGTH,
 };
 
 pub use economics::monitor::{
@@ -2931,6 +2938,124 @@ impl NebulaNomadContract {
     /// Cumulative amount ever minted of a resource, ignoring burns.
     pub fn get_total_minted(env: Env, resource_type: ResourceType) -> u64 {
         resource_minter::total_minted(&env, &resource_type)
+    }
+
+    // ─── Quest System (Issue #282) ────────────────────────────────────────
+
+    /// Create an empty quest chain owned by `creator`.
+    pub fn define_quest_chain(
+        env: Env,
+        creator: Address,
+        name: Symbol,
+    ) -> Result<u64, QuestError> {
+        quest_system::define_chain(&env, creator, name)
+    }
+
+    /// Append a node to a quest chain.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_quest_node(
+        env: Env,
+        creator: Address,
+        chain_id: u64,
+        objective: Symbol,
+        target_count: u32,
+        reward: QuestReward,
+        narrative_tier: Symbol,
+        title: String,
+        description: String,
+        branches: Vec<QuestBranch>,
+        duration_secs: u64,
+    ) -> Result<u64, QuestError> {
+        quest_system::add_quest_node(
+            &env,
+            creator,
+            chain_id,
+            objective,
+            target_count,
+            reward,
+            narrative_tier,
+            title,
+            description,
+            branches,
+            duration_secs,
+        )
+    }
+
+    /// Verify every branch in a chain points at an existing node.
+    pub fn validate_quest_chain(env: Env, chain_id: u64) -> Result<(), QuestError> {
+        quest_system::validate_chain(&env, chain_id)
+    }
+
+    /// Begin a quest chain, activating its root node.
+    pub fn start_quest_chain(
+        env: Env,
+        player: Address,
+        chain_id: u64,
+    ) -> Result<QuestState, QuestError> {
+        quest_system::start_chain(&env, player, chain_id)
+    }
+
+    /// Add progress to an active quest.
+    pub fn record_quest_progress(
+        env: Env,
+        player: Address,
+        quest_id: u64,
+        amount: u32,
+    ) -> Result<QuestState, QuestError> {
+        quest_system::record_progress(&env, player, quest_id, amount)
+    }
+
+    /// Claim the reward for a completed quest.
+    pub fn claim_quest_reward(
+        env: Env,
+        player: Address,
+        quest_id: u64,
+    ) -> Result<QuestReward, QuestError> {
+        quest_system::claim_quest_reward(&env, player, quest_id)
+    }
+
+    /// Take a branch out of a claimed quest, activating the successor node.
+    pub fn choose_quest_branch(
+        env: Env,
+        player: Address,
+        quest_id: u64,
+        choice_id: u32,
+    ) -> Result<Option<QuestState>, QuestError> {
+        quest_system::choose_branch(&env, player, quest_id, choice_id)
+    }
+
+    /// Fetch a quest node definition.
+    pub fn get_quest_node(env: Env, quest_id: u64) -> Option<QuestNode> {
+        quest_system::get_quest_node(&env, quest_id)
+    }
+
+    /// Fetch a quest chain definition.
+    pub fn get_quest_chain(env: Env, chain_id: u64) -> Option<QuestChain> {
+        quest_system::get_chain(&env, chain_id)
+    }
+
+    /// Fetch a player's state for one quest.
+    pub fn get_quest_state(env: Env, player: Address, quest_id: u64) -> Option<QuestState> {
+        quest_system::get_quest_state(&env, &player, quest_id)
+    }
+
+    /// Fetch a player's progress through one chain, including the path walked.
+    pub fn get_quest_chain_progress(
+        env: Env,
+        player: Address,
+        chain_id: u64,
+    ) -> Option<ChainProgress> {
+        quest_system::get_chain_progress(&env, &player, chain_id)
+    }
+
+    /// State records for the player's currently active quests.
+    pub fn get_active_quests(env: Env, player: Address) -> Vec<QuestState> {
+        quest_system::get_active_quest_states(&env, &player)
+    }
+
+    /// IDs of the player's currently active quests.
+    pub fn get_active_quest_ids(env: Env, player: Address) -> Vec<u64> {
+        quest_system::get_active_quests(&env, &player)
     }
 
     // ─── Economic Monitoring & Balancing ──────────────────────────────────

--- a/src/mission_generator.rs
+++ b/src/mission_generator.rs
@@ -48,6 +48,10 @@ pub struct MissionReward {
     pub mission_id: u64,
     pub player: Address,
     pub reward: i128,
+    /// Quest-chain nodes this mission completion advanced (Issue #282).
+    /// Missions are the atoms quests are built from, so claiming one also
+    /// pushes any active quest with a matching objective forward.
+    pub quests_advanced: u32,
 }
 
 pub fn generate_daily_mission(env: &Env, player: Address) -> Result<Mission, MissionError> {
@@ -185,15 +189,26 @@ pub fn complete_mission(
         .persistent()
         .set(&MissionKey::MissionData(mission_id), &mission);
 
+    // Issue #282: feed the completion into the quest system so guided content
+    // advances from ordinary play. Quests whose objective does not match — or
+    // which have already expired — are skipped, so this never fails the claim.
+    let quests_advanced = crate::quest_system::on_mission_completed(
+        env,
+        &player,
+        mission.mission_type.clone(),
+        mission.target_count,
+    );
+
     let reward = MissionReward {
         mission_id,
         player: player.clone(),
         reward: mission.reward,
+        quests_advanced,
     };
 
     env.events().publish(
         (symbol_short!("mission"), symbol_short!("complete")),
-        (mission_id, player, mission.reward),
+        (mission_id, player, mission.reward, quests_advanced),
     );
 
     Ok(reward)

--- a/src/nft_marketplace.rs
+++ b/src/nft_marketplace.rs
@@ -1,10 +1,29 @@
-//! NFT Marketplace integration — Issue #130
+//! NFT Marketplace integration — Issues #130 and #283
 //!
 //! Enables ship NFTs to be listed, purchased, and delisted on-chain.
 //! Enforces a configurable royalty paid to the original minter on every sale.
 //! Emits events compatible with off-chain marketplace indexers.
+//!
+//! Issue #283 adds a parallel **cosmetic** market for skin NFTs. It is kept
+//! separate from the ship market rather than generalised over both, because the
+//! two have different rules: cosmetics carry a creator royalty that follows the
+//! item forever, are floor-priced by rarity (see
+//! [`crate::skins::rarity_floor_price`]), and are escrowed while listed. None of
+//! that applies to ships.
+//!
+//! Cosmetics are strictly non-functional — a skin changes colours and effect
+//! layers only (see [`crate::skins::SkinPreview`]) and never ship stats — so the
+//! market is revenue without pay-to-win.
+//!
+//! Settlement follows the same convention as the ship market above: prices,
+//! fees and royalties are computed and recorded on-chain and published as
+//! events; the value transfer itself is performed by the payment rail that
+//! consumes those events.
 
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env};
+
+use crate::ship_customization::{self, SkinError, SkinRarity};
+use crate::skins::{self, SkinPreview};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -12,6 +31,19 @@ use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env};
 pub const ROYALTY_BPS: i128 = 500;
 /// Maximum number of active listings per seller.
 pub const MAX_LISTINGS_PER_SELLER: u32 = 20;
+
+/// Basis-point denominator.
+pub const BPS_DENOMINATOR: i128 = 10_000;
+/// Platform fee taken on every cosmetic sale (2.5 %).
+pub const PLATFORM_FEE_BPS: i128 = 250;
+/// Creator royalty applied when a cosmetic's creator has not registered a
+/// custom rate (5 %).
+pub const CREATOR_ROYALTY_BPS_DEFAULT: i128 = 500;
+/// Ceiling on a creator-chosen royalty (20 %), so a creator cannot price their
+/// own cosmetics out of the secondary market.
+pub const MAX_CREATOR_ROYALTY_BPS: i128 = 2_000;
+/// Maximum active cosmetic listings per seller.
+pub const MAX_COSMETIC_LISTINGS_PER_SELLER: u32 = 50;
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 
@@ -24,6 +56,27 @@ pub enum MarketplaceKey {
     SellerCount(Address),
     /// Total volume traded (sum of sale prices).
     TotalVolume,
+    // ── Cosmetic market (Issue #283) ──────────────────────────────────────
+    /// Cosmetic listing keyed by skin_id.
+    CosmeticListing(u64),
+    /// Number of active cosmetic listings per seller.
+    CosmeticSellerCount(Address),
+    /// Registered creator royalty for a skin_id.
+    CreatorRoyalty(u64),
+    /// Royalties accrued to a creator across all of their cosmetics.
+    CreatorEarnings(Address),
+    /// Lifetime royalties withdrawn by a creator.
+    CreatorWithdrawn(Address),
+    /// Cumulative cosmetic sale volume.
+    CosmeticVolume,
+    /// Number of cosmetic sales settled.
+    CosmeticSales,
+    /// Cosmetic listings currently open.
+    CosmeticActiveListings,
+    /// Cumulative creator royalties credited.
+    CosmeticRoyaltiesPaid,
+    /// Cumulative platform fees taken.
+    CosmeticFeesCollected,
 }
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -39,6 +92,54 @@ pub struct Listing {
     pub listed_at: u64,
 }
 
+/// A creator's perpetual royalty claim on one cosmetic.
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct CreatorRoyalty {
+    pub skin_id: u64,
+    pub creator: Address,
+    /// Royalty rate in basis points, at most [`MAX_CREATOR_ROYALTY_BPS`].
+    pub bps: i128,
+    pub registered_at: u64,
+}
+
+/// An active cosmetic (skin NFT) listing.
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct CosmeticListing {
+    pub skin_id: u64,
+    pub seller: Address,
+    /// Sale price in stroops; never below the rarity floor.
+    pub price: i128,
+    pub rarity: SkinRarity,
+    /// Registered creator, when the cosmetic has one.
+    pub creator: Option<Address>,
+    /// Royalty rate that will be applied on sale.
+    pub royalty_bps: i128,
+    pub listed_at: u64,
+}
+
+/// Aggregate cosmetic-market statistics.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CosmeticMarketStats {
+    pub total_volume: i128,
+    pub sales_count: u64,
+    pub active_listings: u32,
+    pub creator_royalties_paid: i128,
+    pub platform_fees_collected: i128,
+}
+
+/// How a cosmetic's sale price is split.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct SaleSplit {
+    pub price: i128,
+    pub creator_royalty: i128,
+    pub platform_fee: i128,
+    pub seller_proceeds: i128,
+}
+
 // ── Errors ────────────────────────────────────────────────────────────────────
 
 #[contracterror]
@@ -50,6 +151,32 @@ pub enum MarketplaceError {
     InvalidPrice = 4,
     SellerListingCapReached = 5,
     SelfPurchase = 6,
+    // ── Cosmetic market (Issue #283) ──────────────────────────────────────
+    /// No skin exists with the given ID.
+    SkinNotFound = 7,
+    /// The seller does not own the skin they are listing.
+    NotSkinOwner = 8,
+    /// The skin is escrowed by another listing or otherwise locked.
+    SkinNotTradeable = 9,
+    /// Price is below the floor for the cosmetic's rarity.
+    PriceBelowRarityFloor = 10,
+    /// Requested royalty exceeds [`MAX_CREATOR_ROYALTY_BPS`].
+    RoyaltyTooHigh = 11,
+    /// A royalty is already registered for this cosmetic.
+    RoyaltyAlreadyRegistered = 12,
+    /// The creator has no unwithdrawn royalties.
+    NothingToWithdraw = 13,
+    /// Fee or royalty accounting overflowed.
+    ArithmeticOverflow = 14,
+}
+
+impl From<SkinError> for MarketplaceError {
+    fn from(e: SkinError) -> Self {
+        match e {
+            SkinError::NotOwner => MarketplaceError::NotSkinOwner,
+            _ => MarketplaceError::SkinNotFound,
+        }
+    }
 }
 
 // ── Functions ─────────────────────────────────────────────────────────────────
@@ -201,4 +328,998 @@ pub fn get_total_volume(env: &Env) -> i128 {
         .persistent()
         .get(&MarketplaceKey::TotalVolume)
         .unwrap_or(0)
+}
+
+// ═══ Cosmetic NFT marketplace (Issue #283) ════════════════════════════════════
+
+// ── Creator royalties ─────────────────────────────────────────────────────────
+
+/// Register a perpetual royalty on `skin_id` in favour of `creator`.
+///
+/// Only the cosmetic's current owner may register — in practice its minter,
+/// before the first sale — and only once, so a later holder cannot redirect the
+/// royalty stream to themselves. Passing `bps` of 0 opts out of royalties
+/// entirely; omit the registration to accept
+/// [`CREATOR_ROYALTY_BPS_DEFAULT`] with no named creator.
+pub fn register_creator_royalty(
+    env: &Env,
+    creator: &Address,
+    skin_id: u64,
+    bps: i128,
+) -> Result<CreatorRoyalty, MarketplaceError> {
+    creator.require_auth();
+
+    if bps < 0 || bps > MAX_CREATOR_ROYALTY_BPS {
+        return Err(MarketplaceError::RoyaltyTooHigh);
+    }
+    if env
+        .storage()
+        .persistent()
+        .has(&MarketplaceKey::CreatorRoyalty(skin_id))
+    {
+        return Err(MarketplaceError::RoyaltyAlreadyRegistered);
+    }
+
+    let skin = ship_customization::get_skin(env, skin_id).ok_or(MarketplaceError::SkinNotFound)?;
+    if skin.owner != *creator {
+        return Err(MarketplaceError::NotSkinOwner);
+    }
+
+    let royalty = CreatorRoyalty {
+        skin_id,
+        creator: creator.clone(),
+        bps,
+        registered_at: env.ledger().timestamp(),
+    };
+    env.storage()
+        .persistent()
+        .set(&MarketplaceKey::CreatorRoyalty(skin_id), &royalty);
+
+    env.events().publish(
+        (symbol_short!("cosmetic"), symbol_short!("royalty")),
+        (creator.clone(), skin_id, bps),
+    );
+
+    Ok(royalty)
+}
+
+/// The registered royalty for `skin_id`, if any.
+pub fn get_creator_royalty(env: &Env, skin_id: u64) -> Option<CreatorRoyalty> {
+    env.storage()
+        .persistent()
+        .get(&MarketplaceKey::CreatorRoyalty(skin_id))
+}
+
+/// Royalties credited to `creator` and not yet withdrawn.
+pub fn get_creator_earnings(env: &Env, creator: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&MarketplaceKey::CreatorEarnings(creator.clone()))
+        .unwrap_or(0)
+}
+
+/// Total royalties `creator` has withdrawn over the marketplace's lifetime.
+pub fn get_creator_withdrawn(env: &Env, creator: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&MarketplaceKey::CreatorWithdrawn(creator.clone()))
+        .unwrap_or(0)
+}
+
+/// Withdraw all accrued royalties for `creator`, returning the amount.
+///
+/// Zeroes the balance before emitting, so a re-entrant call finds nothing left
+/// to withdraw.
+pub fn withdraw_creator_earnings(
+    env: &Env,
+    creator: &Address,
+) -> Result<i128, MarketplaceError> {
+    creator.require_auth();
+
+    let owed = get_creator_earnings(env, creator);
+    if owed <= 0 {
+        return Err(MarketplaceError::NothingToWithdraw);
+    }
+
+    env.storage()
+        .persistent()
+        .set(&MarketplaceKey::CreatorEarnings(creator.clone()), &0i128);
+
+    let withdrawn = get_creator_withdrawn(env, creator)
+        .checked_add(owed)
+        .ok_or(MarketplaceError::ArithmeticOverflow)?;
+    env.storage().persistent().set(
+        &MarketplaceKey::CreatorWithdrawn(creator.clone()),
+        &withdrawn,
+    );
+
+    env.events().publish(
+        (symbol_short!("cosmetic"), symbol_short!("withdraw")),
+        (creator.clone(), owed),
+    );
+
+    Ok(owed)
+}
+
+// ── Price splitting ───────────────────────────────────────────────────────────
+
+/// Split `price` into creator royalty, platform fee and seller proceeds.
+///
+/// Pure — clients call it to show a seller exactly what they will net before
+/// the listing is created.
+pub fn compute_sale_split(price: i128, royalty_bps: i128) -> Result<SaleSplit, MarketplaceError> {
+    if price <= 0 {
+        return Err(MarketplaceError::InvalidPrice);
+    }
+
+    let creator_royalty = price
+        .checked_mul(royalty_bps)
+        .ok_or(MarketplaceError::ArithmeticOverflow)?
+        / BPS_DENOMINATOR;
+    let platform_fee = price
+        .checked_mul(PLATFORM_FEE_BPS)
+        .ok_or(MarketplaceError::ArithmeticOverflow)?
+        / BPS_DENOMINATOR;
+
+    // royalty_bps + PLATFORM_FEE_BPS <= 2_250 < 10_000, so the seller's share
+    // is always positive.
+    let seller_proceeds = price - creator_royalty - platform_fee;
+
+    Ok(SaleSplit {
+        price,
+        creator_royalty,
+        platform_fee,
+        seller_proceeds,
+    })
+}
+
+/// Resolve the creator and royalty rate that apply to `skin_id`.
+fn resolve_royalty(env: &Env, skin_id: u64) -> (Option<Address>, i128) {
+    match get_creator_royalty(env, skin_id) {
+        Some(royalty) => (Some(royalty.creator), royalty.bps),
+        None => (None, CREATOR_ROYALTY_BPS_DEFAULT),
+    }
+}
+
+// ── Listing ───────────────────────────────────────────────────────────────────
+
+/// List a cosmetic skin NFT for sale.
+///
+/// Requires the seller to own the skin and the skin to be unlocked. The price
+/// must be at or above the rarity floor. The skin is escrowed — its `tradeable`
+/// flag is cleared — for as long as the listing is open.
+pub fn list_cosmetic(
+    env: &Env,
+    seller: &Address,
+    skin_id: u64,
+    price: i128,
+) -> Result<CosmeticListing, MarketplaceError> {
+    seller.require_auth();
+
+    if price <= 0 {
+        return Err(MarketplaceError::InvalidPrice);
+    }
+    if env
+        .storage()
+        .persistent()
+        .has(&MarketplaceKey::CosmeticListing(skin_id))
+    {
+        return Err(MarketplaceError::AlreadyListed);
+    }
+
+    let skin = ship_customization::get_skin(env, skin_id).ok_or(MarketplaceError::SkinNotFound)?;
+    if skin.owner != *seller {
+        return Err(MarketplaceError::NotSkinOwner);
+    }
+    if !skin.tradeable {
+        return Err(MarketplaceError::SkinNotTradeable);
+    }
+    if price < skins::rarity_floor_price(&skin.rarity) {
+        return Err(MarketplaceError::PriceBelowRarityFloor);
+    }
+
+    let count: u32 = env
+        .storage()
+        .persistent()
+        .get(&MarketplaceKey::CosmeticSellerCount(seller.clone()))
+        .unwrap_or(0);
+    if count >= MAX_COSMETIC_LISTINGS_PER_SELLER {
+        return Err(MarketplaceError::SellerListingCapReached);
+    }
+
+    let (creator, royalty_bps) = resolve_royalty(env, skin_id);
+    let listing = CosmeticListing {
+        skin_id,
+        seller: seller.clone(),
+        price,
+        rarity: skin.rarity.clone(),
+        creator,
+        royalty_bps,
+        listed_at: env.ledger().timestamp(),
+    };
+
+    // Escrow the cosmetic so it cannot be transferred while listed.
+    ship_customization::set_tradeable(env, skin_id, false)?;
+
+    env.storage()
+        .persistent()
+        .set(&MarketplaceKey::CosmeticListing(skin_id), &listing);
+    env.storage().persistent().set(
+        &MarketplaceKey::CosmeticSellerCount(seller.clone()),
+        &count.saturating_add(1),
+    );
+    bump_active_listings(env, 1);
+
+    env.events().publish(
+        (symbol_short!("cosmetic"), symbol_short!("listed")),
+        (seller.clone(), skin_id, price, skin.rarity),
+    );
+
+    Ok(listing)
+}
+
+/// Purchase a listed cosmetic.
+///
+/// Transfers the skin to `buyer`, credits the creator's royalty balance, and
+/// records the platform fee and volume. Returns the settled split.
+pub fn buy_cosmetic(
+    env: &Env,
+    buyer: &Address,
+    skin_id: u64,
+) -> Result<SaleSplit, MarketplaceError> {
+    buyer.require_auth();
+
+    let listing: CosmeticListing = env
+        .storage()
+        .persistent()
+        .get(&MarketplaceKey::CosmeticListing(skin_id))
+        .ok_or(MarketplaceError::NotListed)?;
+
+    if &listing.seller == buyer {
+        return Err(MarketplaceError::SelfPurchase);
+    }
+
+    let split = compute_sale_split(listing.price, listing.royalty_bps)?;
+
+    // Hand over the cosmetic and release it from escrow.
+    ship_customization::transfer_skin_internal(env, skin_id, buyer)?;
+    ship_customization::set_tradeable(env, skin_id, true)?;
+
+    // ── Creator royalty ───────────────────────────────────────────────────
+    // Only a registered creator can be credited; without one the royalty share
+    // stays with the seller rather than accruing to nobody.
+    let creator_royalty = match &listing.creator {
+        Some(creator) if split.creator_royalty > 0 => {
+            let earnings = get_creator_earnings(env, creator)
+                .checked_add(split.creator_royalty)
+                .ok_or(MarketplaceError::ArithmeticOverflow)?;
+            env.storage()
+                .persistent()
+                .set(&MarketplaceKey::CreatorEarnings(creator.clone()), &earnings);
+            bump_i128(env, MarketplaceKey::CosmeticRoyaltiesPaid, split.creator_royalty)?;
+            split.creator_royalty
+        }
+        _ => 0,
+    };
+    let settled = SaleSplit {
+        price: split.price,
+        creator_royalty,
+        platform_fee: split.platform_fee,
+        seller_proceeds: split.price - creator_royalty - split.platform_fee,
+    };
+
+    // ── Bookkeeping ───────────────────────────────────────────────────────
+    bump_i128(env, MarketplaceKey::CosmeticVolume, settled.price)?;
+    bump_i128(
+        env,
+        MarketplaceKey::CosmeticFeesCollected,
+        settled.platform_fee,
+    )?;
+    let sales: u64 = env
+        .storage()
+        .persistent()
+        .get(&MarketplaceKey::CosmeticSales)
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&MarketplaceKey::CosmeticSales, &sales.saturating_add(1));
+
+    close_listing(env, &listing);
+
+    env.events().publish(
+        (symbol_short!("cosmetic"), symbol_short!("sold")),
+        (
+            buyer.clone(),
+            listing.seller.clone(),
+            skin_id,
+            settled.price,
+            settled.creator_royalty,
+            settled.platform_fee,
+            settled.seller_proceeds,
+        ),
+    );
+
+    Ok(settled)
+}
+
+/// Cancel an open cosmetic listing, releasing the skin from escrow.
+pub fn cancel_cosmetic_listing(
+    env: &Env,
+    seller: &Address,
+    skin_id: u64,
+) -> Result<(), MarketplaceError> {
+    seller.require_auth();
+
+    let listing: CosmeticListing = env
+        .storage()
+        .persistent()
+        .get(&MarketplaceKey::CosmeticListing(skin_id))
+        .ok_or(MarketplaceError::NotListed)?;
+
+    if &listing.seller != seller {
+        return Err(MarketplaceError::NotSeller);
+    }
+
+    ship_customization::set_tradeable(env, skin_id, true)?;
+    close_listing(env, &listing);
+
+    env.events().publish(
+        (symbol_short!("cosmetic"), symbol_short!("cancel")),
+        (seller.clone(), skin_id),
+    );
+
+    Ok(())
+}
+
+/// Remove a listing and decrement the seller's and global counters.
+fn close_listing(env: &Env, listing: &CosmeticListing) {
+    env.storage()
+        .persistent()
+        .remove(&MarketplaceKey::CosmeticListing(listing.skin_id));
+
+    let count: u32 = env
+        .storage()
+        .persistent()
+        .get(&MarketplaceKey::CosmeticSellerCount(listing.seller.clone()))
+        .unwrap_or(1);
+    env.storage().persistent().set(
+        &MarketplaceKey::CosmeticSellerCount(listing.seller.clone()),
+        &count.saturating_sub(1),
+    );
+
+    bump_active_listings(env, -1);
+}
+
+fn bump_active_listings(env: &Env, delta: i32) {
+    let current: u32 = env
+        .storage()
+        .persistent()
+        .get(&MarketplaceKey::CosmeticActiveListings)
+        .unwrap_or(0);
+    let updated = if delta >= 0 {
+        current.saturating_add(delta as u32)
+    } else {
+        current.saturating_sub((-delta) as u32)
+    };
+    env.storage()
+        .persistent()
+        .set(&MarketplaceKey::CosmeticActiveListings, &updated);
+}
+
+fn bump_i128(env: &Env, key: MarketplaceKey, delta: i128) -> Result<(), MarketplaceError> {
+    let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+    let updated = current
+        .checked_add(delta)
+        .ok_or(MarketplaceError::ArithmeticOverflow)?;
+    env.storage().persistent().set(&key, &updated);
+    Ok(())
+}
+
+// ── Queries ───────────────────────────────────────────────────────────────────
+
+/// The open cosmetic listing for `skin_id`, if any.
+pub fn get_cosmetic_listing(env: &Env, skin_id: u64) -> Option<CosmeticListing> {
+    env.storage()
+        .persistent()
+        .get(&MarketplaceKey::CosmeticListing(skin_id))
+}
+
+/// Render a listed cosmetic for a storefront card, without owning it.
+pub fn preview_cosmetic_listing(env: &Env, skin_id: u64) -> Option<SkinPreview> {
+    let skin = ship_customization::get_skin(env, skin_id)?;
+    Some(skins::preview_skin(env, &skin))
+}
+
+/// Aggregate cosmetic-market statistics.
+pub fn get_cosmetic_market_stats(env: &Env) -> CosmeticMarketStats {
+    CosmeticMarketStats {
+        total_volume: env
+            .storage()
+            .persistent()
+            .get(&MarketplaceKey::CosmeticVolume)
+            .unwrap_or(0),
+        sales_count: env
+            .storage()
+            .persistent()
+            .get(&MarketplaceKey::CosmeticSales)
+            .unwrap_or(0),
+        active_listings: env
+            .storage()
+            .persistent()
+            .get(&MarketplaceKey::CosmeticActiveListings)
+            .unwrap_or(0),
+        creator_royalties_paid: env
+            .storage()
+            .persistent()
+            .get(&MarketplaceKey::CosmeticRoyaltiesPaid)
+            .unwrap_or(0),
+        platform_fees_collected: env
+            .storage()
+            .persistent()
+            .get(&MarketplaceKey::CosmeticFeesCollected)
+            .unwrap_or(0),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests — cosmetic marketplace (Issue #283)
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod cosmetic_tests {
+    use super::*;
+    use soroban_sdk::{contract, contractimpl, testutils::Address as _, Bytes};
+
+    #[contract]
+    struct Stub;
+    #[contractimpl]
+    impl Stub {}
+
+    /// Listings, escrow and royalty balances all live in contract storage, so
+    /// every test body runs through `Env::as_contract`. Each `run` is its own
+    /// invocation frame, which also mirrors reality: listing, buying and
+    /// cancelling are separate transactions, and `require_auth` may only be
+    /// satisfied once per frame.
+    struct Market {
+        env: Env,
+        contract: Address,
+        seller: Address,
+        buyer: Address,
+    }
+
+    fn market() -> Market {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = env.register(Stub, ());
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+        Market {
+            env,
+            contract,
+            seller,
+            buyer,
+        }
+    }
+
+    impl Market {
+        fn run<T>(&self, f: impl FnOnce() -> T) -> T {
+            self.env.as_contract(&self.contract, f)
+        }
+
+        /// Mint a cosmetic of `rarity` owned by `owner` and return its skin ID.
+        fn mint(&self, owner: &Address, rarity: SkinRarity) -> u64 {
+            self.run(|| {
+                ship_customization::mint_skin(
+                    &self.env,
+                    owner,
+                    symbol_short!("flame"),
+                    rarity,
+                    0xFF4400,
+                    0xFF8800,
+                    Bytes::new(&self.env),
+                )
+                .unwrap()
+                .skin_id
+            })
+        }
+    }
+
+    // ── Listing ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn listing_escrows_the_cosmetic_and_records_the_rarity() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+
+        let listing = m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 5_000).unwrap());
+
+        assert_eq!(listing.skin_id, skin_id);
+        assert_eq!(listing.price, 5_000);
+        assert_eq!(listing.rarity, SkinRarity::Epic);
+        assert_eq!(listing.royalty_bps, CREATOR_ROYALTY_BPS_DEFAULT);
+        assert!(listing.creator.is_none());
+
+        m.run(|| {
+            let skin = ship_customization::get_skin(&m.env, skin_id).unwrap();
+            assert!(!skin.tradeable, "a listed cosmetic must be escrowed");
+            assert_eq!(get_cosmetic_market_stats(&m.env).active_listings, 1);
+        });
+    }
+
+    #[test]
+    fn listing_enforces_the_rarity_price_floor() {
+        let m = market();
+        let legendary = m.mint(&m.seller, SkinRarity::Legendary);
+
+        m.run(|| {
+            assert_eq!(
+                list_cosmetic(&m.env, &m.seller, legendary, 9_999),
+                Err(MarketplaceError::PriceBelowRarityFloor)
+            );
+        });
+        // Exactly at the floor is accepted.
+        m.run(|| assert!(list_cosmetic(&m.env, &m.seller, legendary, 10_000).is_ok()));
+    }
+
+    #[test]
+    fn common_cosmetics_have_a_lower_floor_than_legendary_ones() {
+        let m = market();
+        let common = m.mint(&m.seller, SkinRarity::Common);
+        // 100 would be rejected for a Legendary but is fine for a Common.
+        m.run(|| assert!(list_cosmetic(&m.env, &m.seller, common, 100).is_ok()));
+    }
+
+    #[test]
+    fn listing_rejects_non_positive_prices() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Common);
+
+        m.run(|| {
+            assert_eq!(
+                list_cosmetic(&m.env, &m.seller, skin_id, 0),
+                Err(MarketplaceError::InvalidPrice)
+            );
+        });
+        m.run(|| {
+            assert_eq!(
+                list_cosmetic(&m.env, &m.seller, skin_id, -100),
+                Err(MarketplaceError::InvalidPrice)
+            );
+        });
+    }
+
+    #[test]
+    fn only_the_owner_may_list_a_cosmetic() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Rare);
+
+        m.run(|| {
+            assert_eq!(
+                list_cosmetic(&m.env, &m.buyer, skin_id, 500),
+                Err(MarketplaceError::NotSkinOwner)
+            );
+        });
+    }
+
+    #[test]
+    fn listing_an_unknown_cosmetic_fails() {
+        let m = market();
+        m.run(|| {
+            assert_eq!(
+                list_cosmetic(&m.env, &m.seller, 404, 500),
+                Err(MarketplaceError::SkinNotFound)
+            );
+        });
+    }
+
+    #[test]
+    fn a_cosmetic_cannot_be_listed_twice() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Rare);
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 500).unwrap());
+
+        m.run(|| {
+            assert_eq!(
+                list_cosmetic(&m.env, &m.seller, skin_id, 900),
+                Err(MarketplaceError::AlreadyListed)
+            );
+        });
+    }
+
+    #[test]
+    fn an_escrowed_cosmetic_cannot_be_transferred_by_its_owner() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Rare);
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 500).unwrap());
+
+        // `transfer_skin` refuses a non-tradeable skin, so the seller cannot
+        // move the cosmetic out from under an open listing.
+        m.run(|| {
+            assert!(ship_customization::transfer_skin(&m.env, skin_id, &m.buyer).is_err());
+        });
+        m.run(|| {
+            assert_eq!(
+                ship_customization::get_skin(&m.env, skin_id).unwrap().owner,
+                m.seller
+            );
+        });
+    }
+
+    // ── Buying ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn buying_transfers_ownership_and_closes_the_listing() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 4_000).unwrap());
+
+        let split = m.run(|| buy_cosmetic(&m.env, &m.buyer, skin_id).unwrap());
+
+        assert_eq!(split.price, 4_000);
+        m.run(|| {
+            let skin = ship_customization::get_skin(&m.env, skin_id).unwrap();
+            assert_eq!(skin.owner, m.buyer);
+            assert!(skin.tradeable, "a sold cosmetic leaves escrow");
+            assert!(get_cosmetic_listing(&m.env, skin_id).is_none());
+
+            let stats = get_cosmetic_market_stats(&m.env);
+            assert_eq!(stats.sales_count, 1);
+            assert_eq!(stats.total_volume, 4_000);
+            assert_eq!(stats.active_listings, 0);
+        });
+    }
+
+    #[test]
+    fn buying_moves_the_cosmetic_between_owner_inventories() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Rare);
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 500).unwrap());
+        m.run(|| buy_cosmetic(&m.env, &m.buyer, skin_id).unwrap());
+
+        m.run(|| {
+            assert_eq!(
+                ship_customization::get_owner_skins(&m.env, &m.seller).len(),
+                0
+            );
+            assert_eq!(
+                ship_customization::get_owner_skins(&m.env, &m.buyer).len(),
+                1
+            );
+        });
+    }
+
+    #[test]
+    fn a_seller_cannot_buy_their_own_cosmetic() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Rare);
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 500).unwrap());
+
+        m.run(|| {
+            assert_eq!(
+                buy_cosmetic(&m.env, &m.seller, skin_id),
+                Err(MarketplaceError::SelfPurchase)
+            );
+        });
+    }
+
+    #[test]
+    fn buying_an_unlisted_cosmetic_fails() {
+        let m = market();
+        m.run(|| {
+            assert_eq!(
+                buy_cosmetic(&m.env, &m.buyer, 7),
+                Err(MarketplaceError::NotListed)
+            );
+        });
+    }
+
+    #[test]
+    fn a_cosmetic_can_be_resold_after_purchase() {
+        let m = market();
+        let third = Address::generate(&m.env);
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 2_000).unwrap());
+        m.run(|| buy_cosmetic(&m.env, &m.buyer, skin_id).unwrap());
+        m.run(|| list_cosmetic(&m.env, &m.buyer, skin_id, 3_000).unwrap());
+        m.run(|| buy_cosmetic(&m.env, &third, skin_id).unwrap());
+
+        m.run(|| {
+            assert_eq!(
+                ship_customization::get_skin(&m.env, skin_id).unwrap().owner,
+                third
+            );
+            let stats = get_cosmetic_market_stats(&m.env);
+            assert_eq!(stats.sales_count, 2);
+            assert_eq!(stats.total_volume, 5_000);
+        });
+    }
+
+    // ── Cancelling ────────────────────────────────────────────────────────
+
+    #[test]
+    fn cancelling_releases_the_cosmetic_from_escrow() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Rare);
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 500).unwrap());
+
+        m.run(|| cancel_cosmetic_listing(&m.env, &m.seller, skin_id).unwrap());
+
+        m.run(|| {
+            assert!(get_cosmetic_listing(&m.env, skin_id).is_none());
+            assert!(
+                ship_customization::get_skin(&m.env, skin_id)
+                    .unwrap()
+                    .tradeable
+            );
+            assert_eq!(get_cosmetic_market_stats(&m.env).active_listings, 0);
+        });
+    }
+
+    #[test]
+    fn only_the_seller_may_cancel() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Rare);
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 500).unwrap());
+
+        m.run(|| {
+            assert_eq!(
+                cancel_cosmetic_listing(&m.env, &m.buyer, skin_id),
+                Err(MarketplaceError::NotSeller)
+            );
+        });
+        m.run(|| {
+            assert_eq!(
+                cancel_cosmetic_listing(&m.env, &m.seller, 999),
+                Err(MarketplaceError::NotListed)
+            );
+        });
+    }
+
+    // ── Creator marketplace ───────────────────────────────────────────────
+
+    #[test]
+    fn a_registered_creator_earns_royalties_on_every_sale() {
+        let m = market();
+        let third = Address::generate(&m.env);
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+
+        // The minter registers a 10 % perpetual royalty before selling.
+        m.run(|| register_creator_royalty(&m.env, &m.seller, skin_id, 1_000).unwrap());
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 10_000).unwrap());
+        let first = m.run(|| buy_cosmetic(&m.env, &m.buyer, skin_id).unwrap());
+
+        assert_eq!(first.creator_royalty, 1_000);
+        assert_eq!(first.platform_fee, 250);
+        assert_eq!(first.seller_proceeds, 8_750);
+        m.run(|| assert_eq!(get_creator_earnings(&m.env, &m.seller), 1_000));
+
+        // The royalty follows the cosmetic to the next sale, where the
+        // creator is no longer the seller.
+        m.run(|| list_cosmetic(&m.env, &m.buyer, skin_id, 20_000).unwrap());
+        let second = m.run(|| buy_cosmetic(&m.env, &third, skin_id).unwrap());
+
+        assert_eq!(second.creator_royalty, 2_000);
+        m.run(|| {
+            assert_eq!(get_creator_earnings(&m.env, &m.seller), 3_000);
+            assert_eq!(
+                get_cosmetic_market_stats(&m.env).creator_royalties_paid,
+                3_000
+            );
+        });
+    }
+
+    #[test]
+    fn an_unregistered_cosmetic_pays_no_royalty_to_anyone() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 10_000).unwrap());
+
+        let split = m.run(|| buy_cosmetic(&m.env, &m.buyer, skin_id).unwrap());
+
+        assert_eq!(split.creator_royalty, 0);
+        assert_eq!(split.platform_fee, 250);
+        assert_eq!(
+            split.seller_proceeds, 9_750,
+            "with no creator, the royalty share stays with the seller"
+        );
+        m.run(|| {
+            assert_eq!(get_cosmetic_market_stats(&m.env).creator_royalties_paid, 0);
+        });
+    }
+
+    #[test]
+    fn a_creator_may_opt_out_of_royalties() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+        m.run(|| register_creator_royalty(&m.env, &m.seller, skin_id, 0).unwrap());
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 10_000).unwrap());
+
+        let split = m.run(|| buy_cosmetic(&m.env, &m.buyer, skin_id).unwrap());
+        assert_eq!(split.creator_royalty, 0);
+        m.run(|| assert_eq!(get_creator_earnings(&m.env, &m.seller), 0));
+    }
+
+    #[test]
+    fn royalty_rates_are_capped() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+
+        m.run(|| {
+            assert_eq!(
+                register_creator_royalty(&m.env, &m.seller, skin_id, MAX_CREATOR_ROYALTY_BPS + 1),
+                Err(MarketplaceError::RoyaltyTooHigh)
+            );
+        });
+        m.run(|| {
+            assert_eq!(
+                register_creator_royalty(&m.env, &m.seller, skin_id, -1),
+                Err(MarketplaceError::RoyaltyTooHigh)
+            );
+        });
+        m.run(|| assert!(get_creator_royalty(&m.env, skin_id).is_none()));
+    }
+
+    #[test]
+    fn a_later_holder_cannot_redirect_the_royalty() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+        m.run(|| register_creator_royalty(&m.env, &m.seller, skin_id, 500).unwrap());
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 2_000).unwrap());
+        m.run(|| buy_cosmetic(&m.env, &m.buyer, skin_id).unwrap());
+
+        // The buyer now owns the cosmetic but the royalty is already claimed.
+        m.run(|| {
+            assert_eq!(
+                register_creator_royalty(&m.env, &m.buyer, skin_id, 2_000),
+                Err(MarketplaceError::RoyaltyAlreadyRegistered)
+            );
+        });
+        m.run(|| {
+            assert_eq!(
+                get_creator_royalty(&m.env, skin_id).unwrap().creator,
+                m.seller
+            );
+        });
+    }
+
+    #[test]
+    fn only_the_owner_may_register_a_royalty() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+
+        m.run(|| {
+            assert_eq!(
+                register_creator_royalty(&m.env, &m.buyer, skin_id, 500),
+                Err(MarketplaceError::NotSkinOwner)
+            );
+        });
+        m.run(|| {
+            assert_eq!(
+                register_creator_royalty(&m.env, &m.seller, 404, 500),
+                Err(MarketplaceError::SkinNotFound)
+            );
+        });
+    }
+
+    #[test]
+    fn creators_can_withdraw_their_royalties_once() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+        m.run(|| register_creator_royalty(&m.env, &m.seller, skin_id, 1_000).unwrap());
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 10_000).unwrap());
+        m.run(|| buy_cosmetic(&m.env, &m.buyer, skin_id).unwrap());
+
+        m.run(|| {
+            assert_eq!(withdraw_creator_earnings(&m.env, &m.seller).unwrap(), 1_000);
+        });
+        m.run(|| {
+            assert_eq!(get_creator_earnings(&m.env, &m.seller), 0);
+            assert_eq!(get_creator_withdrawn(&m.env, &m.seller), 1_000);
+        });
+
+        m.run(|| {
+            assert_eq!(
+                withdraw_creator_earnings(&m.env, &m.seller),
+                Err(MarketplaceError::NothingToWithdraw)
+            );
+        });
+    }
+
+    #[test]
+    fn withdrawing_with_no_earnings_fails() {
+        let m = market();
+        m.run(|| {
+            assert_eq!(
+                withdraw_creator_earnings(&m.env, &m.seller),
+                Err(MarketplaceError::NothingToWithdraw)
+            );
+        });
+    }
+
+    // ── Split arithmetic ──────────────────────────────────────────────────
+
+    #[test]
+    fn the_sale_split_always_accounts_for_the_full_price() {
+        for price in [100i128, 500, 2_000, 10_000, 123_457] {
+            for bps in [0i128, 250, 500, MAX_CREATOR_ROYALTY_BPS] {
+                let split = compute_sale_split(price, bps).unwrap();
+                assert_eq!(
+                    split.creator_royalty + split.platform_fee + split.seller_proceeds,
+                    price,
+                    "price {price} at {bps} bps must reconcile exactly"
+                );
+                assert!(split.seller_proceeds > 0);
+            }
+        }
+    }
+
+    #[test]
+    fn the_split_rejects_non_positive_prices() {
+        assert_eq!(
+            compute_sale_split(0, 500),
+            Err(MarketplaceError::InvalidPrice)
+        );
+        assert_eq!(
+            compute_sale_split(-1, 500),
+            Err(MarketplaceError::InvalidPrice)
+        );
+    }
+
+    #[test]
+    fn the_split_detects_overflow_instead_of_wrapping() {
+        assert_eq!(
+            compute_sale_split(i128::MAX, MAX_CREATOR_ROYALTY_BPS),
+            Err(MarketplaceError::ArithmeticOverflow)
+        );
+    }
+
+    // ── Preview ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn listings_can_be_previewed_before_buying() {
+        let m = market();
+        let skin_id = m.mint(&m.seller, SkinRarity::Epic);
+        m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 2_000).unwrap());
+
+        m.run(|| {
+            let preview = preview_cosmetic_listing(&m.env, skin_id).unwrap();
+            assert_eq!(preview.rarity, SkinRarity::Epic);
+            assert_eq!(preview.color_primary, 0xFF4400);
+            assert_eq!(preview.effect_layers, 2);
+            assert!(preview.floor_price <= 2_000);
+
+            assert!(preview_cosmetic_listing(&m.env, 404).is_none());
+        });
+    }
+
+    // ── Listing caps ──────────────────────────────────────────────────────
+
+    #[test]
+    fn cosmetic_listings_per_seller_are_capped() {
+        let m = market();
+        for _ in 0..MAX_COSMETIC_LISTINGS_PER_SELLER {
+            let skin_id = m.mint(&m.seller, SkinRarity::Common);
+            m.run(|| list_cosmetic(&m.env, &m.seller, skin_id, 100).unwrap());
+        }
+
+        let extra = m.mint(&m.seller, SkinRarity::Common);
+        m.run(|| {
+            assert_eq!(
+                list_cosmetic(&m.env, &m.seller, extra, 100),
+                Err(MarketplaceError::SellerListingCapReached)
+            );
+        });
+    }
+
+    #[test]
+    fn cancelling_frees_a_slot_against_the_cap() {
+        let m = market();
+        let first = m.mint(&m.seller, SkinRarity::Common);
+        m.run(|| list_cosmetic(&m.env, &m.seller, first, 100).unwrap());
+        m.run(|| cancel_cosmetic_listing(&m.env, &m.seller, first).unwrap());
+
+        let second = m.mint(&m.seller, SkinRarity::Common);
+        m.run(|| assert!(list_cosmetic(&m.env, &m.seller, second, 100).is_ok()));
+        m.run(|| assert_eq!(get_cosmetic_market_stats(&m.env).active_listings, 1));
+    }
 }

--- a/src/player_profile.rs
+++ b/src/player_profile.rs
@@ -34,6 +34,13 @@ pub struct PlayerProfile {
     pub achievement_flags: u32,
     pub created_at: u64,
     pub last_updated: u64,
+    /// Consecutive daily-login days (Issue #280). Authoritative streak value —
+    /// [`crate::daily_rewards`] owns the calendar, the profile owns the streak.
+    pub login_streak: u32,
+    /// Best login streak ever achieved.
+    pub longest_login_streak: u32,
+    /// Day index (`timestamp / 86_400`) of the most recent recorded login.
+    pub last_login_day: u64,
 }
 
 /// Single entry for a batch progress update.
@@ -54,6 +61,8 @@ pub enum ProfileError {
     ProfileAlreadyExists = 2,
     Unauthorized = 3,
     BatchTooLarge = 4,
+    /// A balance-modifying operation would have wrapped.
+    ArithmeticOverflow = 5,
 }
 
 // ─── Functions ────────────────────────────────────────────────────────────────
@@ -91,6 +100,9 @@ pub fn initialize_profile(env: &Env, owner: Address) -> Result<u64, ProfileError
         achievement_flags: 0,
         created_at: timestamp,
         last_updated: timestamp,
+        login_streak: 0,
+        longest_login_streak: 0,
+        last_login_day: 0,
     };
 
     env.storage()
@@ -231,4 +243,181 @@ pub fn mark_achievement_unlocked(
         .set(&ProfileKey::Profile(profile_id), &profile);
 
     Ok(())
+}
+
+// ─── Reward Crediting (Issue #280) ────────────────────────────────────────────
+
+/// Credit `amount` essence to a profile without requiring the owner's auth.
+///
+/// Intended for reward-granting subsystems (daily logins, quests) that have
+/// already established the caller's right to the payout. Rejects negative
+/// amounts so it can never be used as a debit path, and uses checked
+/// arithmetic per the crate-wide overflow policy.
+pub fn credit_essence(env: &Env, profile_id: u64, amount: i128) -> Result<i128, ProfileError> {
+    if amount < 0 {
+        return Err(ProfileError::Unauthorized);
+    }
+
+    let mut profile = get_profile(env, profile_id)?;
+    profile.essence_earned = profile
+        .essence_earned
+        .checked_add(amount)
+        .ok_or(ProfileError::ArithmeticOverflow)?;
+    profile.last_updated = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&ProfileKey::Profile(profile_id), &profile);
+
+    env.events().publish(
+        (symbol_short!("profile"), symbol_short!("credited")),
+        (profile_id, amount, profile.essence_earned),
+    );
+
+    Ok(profile.essence_earned)
+}
+
+/// Record a daily login against a profile.
+///
+/// `login_day` is a `timestamp / 86_400` day index and `streak` the streak the
+/// caller computed for that day; the profile stores both so any subsystem can
+/// read the streak without re-deriving it. Stale writes (a `login_day` at or
+/// before the one already stored) are ignored rather than rejected, keeping the
+/// call idempotent for retried transactions.
+pub fn record_login(
+    env: &Env,
+    profile_id: u64,
+    login_day: u64,
+    streak: u32,
+) -> Result<u32, ProfileError> {
+    let mut profile = get_profile(env, profile_id)?;
+
+    if login_day <= profile.last_login_day && profile.last_login_day != 0 {
+        return Ok(profile.login_streak);
+    }
+
+    profile.login_streak = streak;
+    profile.longest_login_streak = profile.longest_login_streak.max(streak);
+    profile.last_login_day = login_day;
+    profile.last_updated = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&ProfileKey::Profile(profile_id), &profile);
+
+    env.events().publish(
+        (symbol_short!("profile"), symbol_short!("login")),
+        (profile_id, login_day, streak),
+    );
+
+    Ok(streak)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{contract, contractimpl};
+
+    #[contract]
+    struct Stub;
+    #[contractimpl]
+    impl Stub {}
+
+    /// Storage is only reachable inside a contract invocation, so each test
+    /// body runs through `Env::as_contract`.
+    fn with_profile<T>(f: impl FnOnce(&Env, u64) -> T) -> T {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = env.register(Stub, ());
+        let owner = Address::generate(&env);
+
+        let id = env.as_contract(&contract, || {
+            initialize_profile(&env, owner.clone()).unwrap()
+        });
+        env.as_contract(&contract, || f(&env, id))
+    }
+
+    #[test]
+    fn new_profile_starts_with_no_login_history() {
+        with_profile(|env, id| {
+            let profile = get_profile(env, id).unwrap();
+            assert_eq!(profile.login_streak, 0);
+            assert_eq!(profile.longest_login_streak, 0);
+            assert_eq!(profile.last_login_day, 0);
+        });
+    }
+
+    #[test]
+    fn credit_essence_accumulates() {
+        with_profile(|env, id| {
+            assert_eq!(credit_essence(env, id, 50).unwrap(), 50);
+            assert_eq!(credit_essence(env, id, 25).unwrap(), 75);
+            assert_eq!(get_profile(env, id).unwrap().essence_earned, 75);
+        });
+    }
+
+    #[test]
+    fn credit_essence_rejects_negative_amounts() {
+        with_profile(|env, id| {
+            assert_eq!(credit_essence(env, id, -1), Err(ProfileError::Unauthorized));
+            assert_eq!(get_profile(env, id).unwrap().essence_earned, 0);
+        });
+    }
+
+    #[test]
+    fn credit_essence_detects_overflow() {
+        with_profile(|env, id| {
+            credit_essence(env, id, i128::MAX).unwrap();
+            assert_eq!(
+                credit_essence(env, id, 1),
+                Err(ProfileError::ArithmeticOverflow)
+            );
+            // The failed credit left the balance untouched.
+            assert_eq!(get_profile(env, id).unwrap().essence_earned, i128::MAX);
+        });
+    }
+
+    #[test]
+    fn credit_essence_requires_an_existing_profile() {
+        with_profile(|env, _id| {
+            assert_eq!(
+                credit_essence(env, 9_999, 10),
+                Err(ProfileError::ProfileNotFound)
+            );
+        });
+    }
+
+    #[test]
+    fn record_login_tracks_streak_and_best() {
+        with_profile(|env, id| {
+            record_login(env, id, 10, 1).unwrap();
+            record_login(env, id, 11, 2).unwrap();
+            record_login(env, id, 12, 3).unwrap();
+            assert_eq!(get_profile(env, id).unwrap().longest_login_streak, 3);
+
+            // A broken streak lowers the current value but not the best.
+            record_login(env, id, 20, 1).unwrap();
+            let profile = get_profile(env, id).unwrap();
+            assert_eq!(profile.login_streak, 1);
+            assert_eq!(profile.longest_login_streak, 3);
+            assert_eq!(profile.last_login_day, 20);
+        });
+    }
+
+    #[test]
+    fn record_login_ignores_stale_days() {
+        with_profile(|env, id| {
+            record_login(env, id, 10, 5).unwrap();
+
+            // Replaying an older day must not rewind the profile.
+            assert_eq!(record_login(env, id, 9, 1).unwrap(), 5);
+            let profile = get_profile(env, id).unwrap();
+            assert_eq!(profile.login_streak, 5);
+            assert_eq!(profile.last_login_day, 10);
+        });
+    }
 }

--- a/src/quest_system.rs
+++ b/src/quest_system.rs
@@ -1,0 +1,1682 @@
+//! Quest system — Issue #282
+//!
+//! Guided, multi-step content on top of the one-shot dailies produced by
+//! [`crate::mission_generator`]. Where a mission is a single objective that
+//! expires in a day, a quest is a **node in a chain**: completing it unlocks
+//! one of several successors, so a chain describes a branching narrative rather
+//! than a fixed list.
+//!
+//! ```text
+//!                       ┌── choice 1 ──► node 2 ──► node 4
+//!   chain root: node 1 ─┤
+//!                       └── choice 2 ──► node 3 ──► (end)
+//! ```
+//!
+//! Lifecycle of one node for one player:
+//!
+//! ```text
+//!   Locked ──start/choose──► Active ──progress reaches target──► Completed
+//!                              │                                    │
+//!                              └────────── expires ──────► Expired  ├─claim─► Claimed
+//!                                                                   │
+//!                                                       choose_branch └──► next node Active
+//! ```
+//!
+//! Progress can be recorded directly or fed in from the mission system: a
+//! completed mission calls [`on_mission_completed`], which advances every
+//! active quest whose objective matches the mission type. That means normal
+//! play drives quest chains forward without the player tracking two systems.
+
+use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, String, Symbol, Vec};
+
+use crate::player_profile::{self, ProfileError};
+use crate::resource_minter::{self, ResourceType};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/// Maximum nodes in a single chain — bounds the storage a chain can occupy.
+pub const MAX_CHAIN_LENGTH: u32 = 20;
+
+/// Maximum branch choices offered by one node.
+pub const MAX_BRANCHES_PER_NODE: u32 = 4;
+
+/// Maximum quests a player may have active at once. Also bounds the iteration
+/// in [`on_mission_completed`], keeping that call's cost constant.
+pub const MAX_ACTIVE_QUESTS: u32 = 10;
+
+/// Sentinel used by [`QuestBranch::next_quest_id`] to mean "this path ends
+/// here" — chains terminate on a leaf rather than needing an explicit end node.
+pub const CHAIN_TERMINUS: u64 = 0;
+
+// ─── Storage Keys ─────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+#[contracttype]
+pub enum QuestKey {
+    /// Chain definition by chain ID.
+    Chain(u64),
+    /// Node definition by (globally unique) quest ID.
+    Node(u64),
+    /// Auto-increment chain ID counter.
+    ChainCounter,
+    /// Auto-increment quest (node) ID counter.
+    NodeCounter,
+    /// Per-player state for one node.
+    State(Address, u64),
+    /// Per-player progress through one chain.
+    Progress(Address, u64),
+    /// Quest IDs currently active for a player.
+    ActiveQuests(Address),
+}
+
+// ─── Data Types ───────────────────────────────────────────────────────────────
+
+/// Where a player stands on a single quest node.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum QuestStatus {
+    /// Defined but not yet reachable for this player.
+    Locked,
+    /// Accepted and accruing progress.
+    Active,
+    /// Target met; reward not yet taken.
+    Completed,
+    /// Reward taken.
+    Claimed,
+    /// Deadline passed before the target was met.
+    Expired,
+}
+
+/// A quest payout. Multiple currencies so chains can mix incentives instead of
+/// paying escalating essence at every step.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QuestReward {
+    /// Essence credited to the player's profile.
+    pub essence: i128,
+    /// Resource type granted (ignored when `resource_amount` is 0).
+    pub resource_type: ResourceType,
+    pub resource_amount: u64,
+    /// Experience toward account progression.
+    pub xp: u64,
+    /// Whether the node grants a cosmetic roll.
+    pub cosmetic_roll: bool,
+}
+
+/// One outgoing edge from a quest node — the unit of branching narrative.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QuestBranch {
+    /// Identifier the player passes to [`choose_branch`]. Must be non-zero.
+    pub choice_id: u32,
+    /// Short label for the choice, e.g. `sabotage` / `negotiate`.
+    pub label: Symbol,
+    /// Node unlocked by this choice, or [`CHAIN_TERMINUS`] to end the chain.
+    pub next_quest_id: u64,
+}
+
+/// A quest node: one objective plus the choices that follow it.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QuestNode {
+    pub quest_id: u64,
+    pub chain_id: u64,
+    /// 0-based position in the order the node was added to its chain.
+    pub step_index: u32,
+    /// Objective tag, matched against `Mission::mission_type` when mission
+    /// completions are forwarded in (`scan`, `harvest`, `explore`, `trade`, …).
+    pub objective: Symbol,
+    pub target_count: u32,
+    pub reward: QuestReward,
+    /// Narrative bucket for flavour text selection.
+    pub narrative_tier: Symbol,
+    pub title: String,
+    pub description: String,
+    pub branches: Vec<QuestBranch>,
+    /// Seconds the player has to finish once active; 0 means no deadline.
+    pub duration_secs: u64,
+}
+
+/// A named chain of quest nodes.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QuestChain {
+    pub chain_id: u64,
+    pub name: Symbol,
+    pub creator: Address,
+    /// First node added to the chain; where [`start_chain`] begins.
+    pub root_quest_id: u64,
+    pub node_count: u32,
+}
+
+/// Per-player state for one quest node.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QuestState {
+    pub player: Address,
+    pub quest_id: u64,
+    pub chain_id: u64,
+    pub status: QuestStatus,
+    pub progress: u32,
+    pub target: u32,
+    pub started_at: u64,
+    /// 0 when the node has no deadline.
+    pub expires_at: u64,
+    /// 0 until the target is met.
+    pub completed_at: u64,
+    /// Branch taken after completion; 0 while none has been chosen.
+    pub chosen_branch: u32,
+}
+
+/// Per-player progress through a chain, including the narrative path walked.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChainProgress {
+    pub player: Address,
+    pub chain_id: u64,
+    /// Node the player is currently on, or the last one they finished.
+    pub current_quest_id: u64,
+    pub steps_completed: u32,
+    pub total_essence_earned: i128,
+    /// Branch choice IDs in the order they were taken.
+    pub path: Vec<u32>,
+    /// True once a terminal node has been claimed.
+    pub finished: bool,
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum QuestError {
+    /// No chain with the given ID.
+    ChainNotFound = 1,
+    /// No node with the given quest ID.
+    QuestNotFound = 2,
+    /// The player has no state for this quest.
+    QuestNotStarted = 3,
+    /// The quest is not in a state that allows this operation.
+    InvalidStatus = 4,
+    /// The quest deadline has passed.
+    QuestExpired = 5,
+    /// The reward for this quest was already taken.
+    AlreadyClaimed = 6,
+    /// Chain already holds [`MAX_CHAIN_LENGTH`] nodes.
+    ChainFull = 7,
+    /// Node declares more than [`MAX_BRANCHES_PER_NODE`] branches.
+    TooManyBranches = 8,
+    /// `choice_id` is not offered by this node.
+    InvalidBranch = 9,
+    /// The player already has [`MAX_ACTIVE_QUESTS`] quests active.
+    TooManyActiveQuests = 10,
+    /// Only the chain's creator may extend it.
+    Unauthorized = 11,
+    /// The player already started this chain.
+    ChainAlreadyStarted = 12,
+    /// `target_count` must be greater than zero.
+    InvalidTarget = 13,
+    /// No profile exists for the player, so rewards cannot be credited.
+    ProfileNotFound = 14,
+    /// Reward accounting overflowed.
+    ArithmeticOverflow = 15,
+    /// A branch points at a node that does not exist.
+    DanglingBranch = 16,
+}
+
+impl From<ProfileError> for QuestError {
+    fn from(e: ProfileError) -> Self {
+        match e {
+            ProfileError::ArithmeticOverflow => QuestError::ArithmeticOverflow,
+            _ => QuestError::ProfileNotFound,
+        }
+    }
+}
+
+// ─── Authoring ────────────────────────────────────────────────────────────────
+
+/// Create an empty quest chain owned by `creator`.
+///
+/// Nodes are added afterwards with [`add_quest_node`]; the first node added
+/// becomes the chain's root.
+pub fn define_chain(env: &Env, creator: Address, name: Symbol) -> Result<u64, QuestError> {
+    creator.require_auth();
+
+    let chain_id: u64 = env
+        .storage()
+        .persistent()
+        .get::<QuestKey, u64>(&QuestKey::ChainCounter)
+        .unwrap_or(0)
+        .saturating_add(1);
+    env.storage()
+        .persistent()
+        .set(&QuestKey::ChainCounter, &chain_id);
+
+    let chain = QuestChain {
+        chain_id,
+        name: name.clone(),
+        creator: creator.clone(),
+        root_quest_id: CHAIN_TERMINUS,
+        node_count: 0,
+    };
+    env.storage()
+        .persistent()
+        .set(&QuestKey::Chain(chain_id), &chain);
+
+    env.events().publish(
+        (symbol_short!("quest"), symbol_short!("chaindef")),
+        (creator, chain_id, name),
+    );
+
+    Ok(chain_id)
+}
+
+/// Append a node to `chain_id` and return its quest ID.
+///
+/// `branches` may reference quest IDs that do not exist yet — chains are
+/// authored root-first, so forward edges are resolved when the target node is
+/// added. [`validate_chain`] checks that no dangling edge remains.
+#[allow(clippy::too_many_arguments)]
+pub fn add_quest_node(
+    env: &Env,
+    creator: Address,
+    chain_id: u64,
+    objective: Symbol,
+    target_count: u32,
+    reward: QuestReward,
+    narrative_tier: Symbol,
+    title: String,
+    description: String,
+    branches: Vec<QuestBranch>,
+    duration_secs: u64,
+) -> Result<u64, QuestError> {
+    creator.require_auth();
+
+    let mut chain: QuestChain = env
+        .storage()
+        .persistent()
+        .get(&QuestKey::Chain(chain_id))
+        .ok_or(QuestError::ChainNotFound)?;
+
+    if chain.creator != creator {
+        return Err(QuestError::Unauthorized);
+    }
+    if chain.node_count >= MAX_CHAIN_LENGTH {
+        return Err(QuestError::ChainFull);
+    }
+    if branches.len() > MAX_BRANCHES_PER_NODE {
+        return Err(QuestError::TooManyBranches);
+    }
+    if target_count == 0 {
+        return Err(QuestError::InvalidTarget);
+    }
+    // A zero choice_id would collide with the "no branch chosen" sentinel in
+    // `QuestState::chosen_branch`.
+    for branch in branches.iter() {
+        if branch.choice_id == 0 {
+            return Err(QuestError::InvalidBranch);
+        }
+    }
+
+    let quest_id: u64 = env
+        .storage()
+        .persistent()
+        .get::<QuestKey, u64>(&QuestKey::NodeCounter)
+        .unwrap_or(0)
+        .saturating_add(1);
+    env.storage()
+        .persistent()
+        .set(&QuestKey::NodeCounter, &quest_id);
+
+    let node = QuestNode {
+        quest_id,
+        chain_id,
+        step_index: chain.node_count,
+        objective: objective.clone(),
+        target_count,
+        reward,
+        narrative_tier,
+        title,
+        description,
+        branches,
+        duration_secs,
+    };
+    env.storage()
+        .persistent()
+        .set(&QuestKey::Node(quest_id), &node);
+
+    chain.node_count = chain.node_count.saturating_add(1);
+    if chain.root_quest_id == CHAIN_TERMINUS {
+        chain.root_quest_id = quest_id;
+    }
+    env.storage()
+        .persistent()
+        .set(&QuestKey::Chain(chain_id), &chain);
+
+    env.events().publish(
+        (symbol_short!("quest"), symbol_short!("nodeadd")),
+        (chain_id, quest_id, objective),
+    );
+
+    Ok(quest_id)
+}
+
+/// Check that every branch in `chain_id` points at an existing node.
+///
+/// Authors should call this once a chain is fully written; it is not enforced at
+/// node-insert time because forward references are legitimate while authoring.
+pub fn validate_chain(env: &Env, chain_id: u64) -> Result<(), QuestError> {
+    let chain: QuestChain = env
+        .storage()
+        .persistent()
+        .get(&QuestKey::Chain(chain_id))
+        .ok_or(QuestError::ChainNotFound)?;
+
+    // Node IDs are globally sequential, so walking from the root over the
+    // chain's node count covers exactly this chain's nodes.
+    let first = chain.root_quest_id;
+    for quest_id in first..first.saturating_add(chain.node_count as u64) {
+        let node: QuestNode = match env.storage().persistent().get(&QuestKey::Node(quest_id)) {
+            Some(node) => node,
+            None => continue,
+        };
+        if node.chain_id != chain_id {
+            continue;
+        }
+        for branch in node.branches.iter() {
+            if branch.next_quest_id != CHAIN_TERMINUS
+                && !env
+                    .storage()
+                    .persistent()
+                    .has(&QuestKey::Node(branch.next_quest_id))
+            {
+                return Err(QuestError::DanglingBranch);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ─── Active-quest bookkeeping ─────────────────────────────────────────────────
+
+fn active_quests(env: &Env, player: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&QuestKey::ActiveQuests(player.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn push_active(env: &Env, player: &Address, quest_id: u64) -> Result<(), QuestError> {
+    let mut active = active_quests(env, player);
+    if active.len() >= MAX_ACTIVE_QUESTS {
+        return Err(QuestError::TooManyActiveQuests);
+    }
+    active.push_back(quest_id);
+    env.storage()
+        .persistent()
+        .set(&QuestKey::ActiveQuests(player.clone()), &active);
+    Ok(())
+}
+
+fn remove_active(env: &Env, player: &Address, quest_id: u64) {
+    let active = active_quests(env, player);
+    let mut remaining = Vec::new(env);
+    for id in active.iter() {
+        if id != quest_id {
+            remaining.push_back(id);
+        }
+    }
+    env.storage()
+        .persistent()
+        .set(&QuestKey::ActiveQuests(player.clone()), &remaining);
+}
+
+fn save_state(env: &Env, state: &QuestState) {
+    env.storage().persistent().set(
+        &QuestKey::State(state.player.clone(), state.quest_id),
+        state,
+    );
+}
+
+fn load_state(env: &Env, player: &Address, quest_id: u64) -> Result<QuestState, QuestError> {
+    env.storage()
+        .persistent()
+        .get(&QuestKey::State(player.clone(), quest_id))
+        .ok_or(QuestError::QuestNotStarted)
+}
+
+fn load_node(env: &Env, quest_id: u64) -> Result<QuestNode, QuestError> {
+    env.storage()
+        .persistent()
+        .get(&QuestKey::Node(quest_id))
+        .ok_or(QuestError::QuestNotFound)
+}
+
+/// Activate `node` for `player`, writing state and progress records.
+fn activate(env: &Env, player: &Address, node: &QuestNode) -> Result<QuestState, QuestError> {
+    let now = env.ledger().timestamp();
+    let expires_at = if node.duration_secs == 0 {
+        0
+    } else {
+        now.saturating_add(node.duration_secs)
+    };
+
+    let state = QuestState {
+        player: player.clone(),
+        quest_id: node.quest_id,
+        chain_id: node.chain_id,
+        status: QuestStatus::Active,
+        progress: 0,
+        target: node.target_count,
+        started_at: now,
+        expires_at,
+        completed_at: 0,
+        chosen_branch: 0,
+    };
+
+    push_active(env, player, node.quest_id)?;
+    save_state(env, &state);
+
+    env.events().publish(
+        (symbol_short!("quest"), symbol_short!("started")),
+        (
+            player.clone(),
+            node.quest_id,
+            node.chain_id,
+            node.step_index,
+        ),
+    );
+
+    Ok(state)
+}
+
+// ─── Player flow ──────────────────────────────────────────────────────────────
+
+/// Begin `chain_id` for `player`, activating its root node.
+pub fn start_chain(env: &Env, player: Address, chain_id: u64) -> Result<QuestState, QuestError> {
+    player.require_auth();
+
+    let chain: QuestChain = env
+        .storage()
+        .persistent()
+        .get(&QuestKey::Chain(chain_id))
+        .ok_or(QuestError::ChainNotFound)?;
+
+    if chain.root_quest_id == CHAIN_TERMINUS {
+        return Err(QuestError::QuestNotFound);
+    }
+    if env
+        .storage()
+        .persistent()
+        .has(&QuestKey::Progress(player.clone(), chain_id))
+    {
+        return Err(QuestError::ChainAlreadyStarted);
+    }
+
+    let node = load_node(env, chain.root_quest_id)?;
+    let state = activate(env, &player, &node)?;
+
+    let progress = ChainProgress {
+        player: player.clone(),
+        chain_id,
+        current_quest_id: node.quest_id,
+        steps_completed: 0,
+        total_essence_earned: 0,
+        path: Vec::new(env),
+        finished: false,
+    };
+    env.storage()
+        .persistent()
+        .set(&QuestKey::Progress(player.clone(), chain_id), &progress);
+
+    env.events().publish(
+        (symbol_short!("quest"), symbol_short!("chainstr")),
+        (player, chain_id, node.quest_id),
+    );
+
+    Ok(state)
+}
+
+/// Add `amount` to a player's progress on an active quest.
+///
+/// Transitions the quest to `Completed` once the target is met, and to `Expired`
+/// if the deadline has already passed. Idempotent once the quest leaves
+/// `Active`: further calls return `InvalidStatus` rather than over-counting.
+pub fn record_progress(
+    env: &Env,
+    player: Address,
+    quest_id: u64,
+    amount: u32,
+) -> Result<QuestState, QuestError> {
+    player.require_auth();
+    record_progress_unchecked(env, &player, quest_id, amount)
+}
+
+/// Progress without an auth check, for callers that already authorized `player`.
+fn record_progress_unchecked(
+    env: &Env,
+    player: &Address,
+    quest_id: u64,
+    amount: u32,
+) -> Result<QuestState, QuestError> {
+    let mut state = load_state(env, player, quest_id)?;
+
+    if state.status != QuestStatus::Active {
+        return Err(QuestError::InvalidStatus);
+    }
+
+    let now = env.ledger().timestamp();
+    if state.expires_at != 0 && now > state.expires_at {
+        state.status = QuestStatus::Expired;
+        save_state(env, &state);
+        remove_active(env, player, quest_id);
+
+        env.events().publish(
+            (symbol_short!("quest"), symbol_short!("expired")),
+            (player.clone(), quest_id),
+        );
+        return Err(QuestError::QuestExpired);
+    }
+
+    state.progress = state.progress.saturating_add(amount);
+
+    if state.progress >= state.target {
+        state.progress = state.target;
+        state.status = QuestStatus::Completed;
+        state.completed_at = now;
+        remove_active(env, player, quest_id);
+
+        env.events().publish(
+            (symbol_short!("quest"), symbol_short!("complete")),
+            (player.clone(), quest_id, state.chain_id),
+        );
+    } else {
+        env.events().publish(
+            (symbol_short!("quest"), symbol_short!("progress")),
+            (player.clone(), quest_id, state.progress, state.target),
+        );
+    }
+
+    save_state(env, &state);
+    Ok(state)
+}
+
+/// Claim the reward for a completed quest.
+///
+/// Credits essence to the player's profile and resources to their balance, then
+/// marks the quest `Claimed`. A node whose only branches are
+/// [`CHAIN_TERMINUS`] — or which has no branches at all — finishes the chain
+/// here.
+pub fn claim_quest_reward(
+    env: &Env,
+    player: Address,
+    quest_id: u64,
+) -> Result<QuestReward, QuestError> {
+    player.require_auth();
+
+    let mut state = load_state(env, &player, quest_id)?;
+
+    match state.status {
+        QuestStatus::Completed => {}
+        QuestStatus::Claimed => return Err(QuestError::AlreadyClaimed),
+        QuestStatus::Expired => return Err(QuestError::QuestExpired),
+        _ => return Err(QuestError::InvalidStatus),
+    }
+
+    let node = load_node(env, quest_id)?;
+    let reward = node.reward.clone();
+
+    // ── Pay out ───────────────────────────────────────────────────────────
+    let profile = player_profile::get_profile_by_owner(env, &player)?;
+    if reward.essence > 0 {
+        player_profile::credit_essence(env, profile.id, reward.essence)?;
+    }
+    if reward.resource_amount > 0 {
+        resource_minter::credit_balance(
+            env,
+            &player,
+            &reward.resource_type,
+            reward.resource_amount,
+        )
+        .map_err(|_| QuestError::ArithmeticOverflow)?;
+    }
+
+    state.status = QuestStatus::Claimed;
+    save_state(env, &state);
+
+    // ── Chain progress ────────────────────────────────────────────────────
+    let mut progress =
+        get_chain_progress(env, &player, state.chain_id).ok_or(QuestError::QuestNotStarted)?;
+    progress.steps_completed = progress.steps_completed.saturating_add(1);
+    progress.total_essence_earned = progress
+        .total_essence_earned
+        .checked_add(reward.essence)
+        .ok_or(QuestError::ArithmeticOverflow)?;
+    progress.current_quest_id = quest_id;
+
+    // No onward edge means this path of the narrative ends here.
+    let has_successor = node
+        .branches
+        .iter()
+        .any(|b| b.next_quest_id != CHAIN_TERMINUS);
+    if !has_successor {
+        progress.finished = true;
+        env.events().publish(
+            (symbol_short!("quest"), symbol_short!("chainend")),
+            (player.clone(), state.chain_id, progress.steps_completed),
+        );
+    }
+    env.storage().persistent().set(
+        &QuestKey::Progress(player.clone(), state.chain_id),
+        &progress,
+    );
+
+    env.events().publish(
+        (symbol_short!("quest"), symbol_short!("claimed")),
+        (player, quest_id, reward.essence, reward.xp),
+    );
+
+    Ok(reward)
+}
+
+/// Take a branch out of a claimed quest, activating the successor node.
+///
+/// Returns the newly activated state, or `None` when the chosen branch is a
+/// [`CHAIN_TERMINUS`] leaf. The choice is appended to
+/// [`ChainProgress::path`], which is the record of the narrative walked.
+pub fn choose_branch(
+    env: &Env,
+    player: Address,
+    quest_id: u64,
+    choice_id: u32,
+) -> Result<Option<QuestState>, QuestError> {
+    player.require_auth();
+
+    let mut state = load_state(env, &player, quest_id)?;
+
+    // Branching happens after the reward is taken, so the player cannot skip
+    // past a node's payout by racing ahead in the narrative.
+    if state.status != QuestStatus::Claimed {
+        return Err(QuestError::InvalidStatus);
+    }
+    if state.chosen_branch != 0 {
+        return Err(QuestError::InvalidStatus);
+    }
+
+    let node = load_node(env, quest_id)?;
+    let branch = node
+        .branches
+        .iter()
+        .find(|b| b.choice_id == choice_id)
+        .ok_or(QuestError::InvalidBranch)?;
+
+    state.chosen_branch = choice_id;
+    save_state(env, &state);
+
+    let mut progress =
+        get_chain_progress(env, &player, state.chain_id).ok_or(QuestError::QuestNotStarted)?;
+    progress.path.push_back(choice_id);
+
+    env.events().publish(
+        (symbol_short!("quest"), symbol_short!("branch")),
+        (
+            player.clone(),
+            quest_id,
+            choice_id,
+            branch.label.clone(),
+            branch.next_quest_id,
+        ),
+    );
+
+    if branch.next_quest_id == CHAIN_TERMINUS {
+        progress.finished = true;
+        env.storage().persistent().set(
+            &QuestKey::Progress(player.clone(), state.chain_id),
+            &progress,
+        );
+
+        env.events().publish(
+            (symbol_short!("quest"), symbol_short!("chainend")),
+            (player, state.chain_id, progress.steps_completed),
+        );
+        return Ok(None);
+    }
+
+    let next_node = load_node(env, branch.next_quest_id)?;
+    let next_state = activate(env, &player, &next_node)?;
+
+    progress.current_quest_id = next_node.quest_id;
+    env.storage()
+        .persistent()
+        .set(&QuestKey::Progress(player, state.chain_id), &progress);
+
+    Ok(Some(next_state))
+}
+
+// ─── Mission bridge ───────────────────────────────────────────────────────────
+
+/// Forward a completed mission into the quest system.
+///
+/// Advances every active quest whose `objective` equals `objective` by
+/// `amount`, and returns how many quests were advanced. Errors on individual
+/// quests (expired, already complete) are swallowed: a mission completion must
+/// never fail because of unrelated quest state.
+pub fn on_mission_completed(env: &Env, player: &Address, objective: Symbol, amount: u32) -> u32 {
+    let mut advanced = 0u32;
+
+    for quest_id in active_quests(env, player).iter() {
+        let node = match env
+            .storage()
+            .persistent()
+            .get::<QuestKey, QuestNode>(&QuestKey::Node(quest_id))
+        {
+            Some(node) => node,
+            None => continue,
+        };
+        if node.objective != objective {
+            continue;
+        }
+        if record_progress_unchecked(env, player, quest_id, amount).is_ok() {
+            advanced = advanced.saturating_add(1);
+        }
+    }
+
+    if advanced > 0 {
+        env.events().publish(
+            (symbol_short!("quest"), symbol_short!("misfeed")),
+            (player.clone(), objective, advanced),
+        );
+    }
+
+    advanced
+}
+
+// ─── Queries ──────────────────────────────────────────────────────────────────
+
+/// Fetch a quest node definition.
+pub fn get_quest_node(env: &Env, quest_id: u64) -> Option<QuestNode> {
+    env.storage().persistent().get(&QuestKey::Node(quest_id))
+}
+
+/// Fetch a chain definition.
+pub fn get_chain(env: &Env, chain_id: u64) -> Option<QuestChain> {
+    env.storage().persistent().get(&QuestKey::Chain(chain_id))
+}
+
+/// Fetch a player's state for one quest.
+pub fn get_quest_state(env: &Env, player: &Address, quest_id: u64) -> Option<QuestState> {
+    env.storage()
+        .persistent()
+        .get(&QuestKey::State(player.clone(), quest_id))
+}
+
+/// Fetch a player's progress through one chain.
+pub fn get_chain_progress(env: &Env, player: &Address, chain_id: u64) -> Option<ChainProgress> {
+    env.storage()
+        .persistent()
+        .get(&QuestKey::Progress(player.clone(), chain_id))
+}
+
+/// Quest IDs the player currently has active.
+pub fn get_active_quests(env: &Env, player: &Address) -> Vec<u64> {
+    active_quests(env, player)
+}
+
+/// Full state records for the player's active quests.
+pub fn get_active_quest_states(env: &Env, player: &Address) -> Vec<QuestState> {
+    let mut states = Vec::new(env);
+    for quest_id in active_quests(env, player).iter() {
+        if let Some(state) = get_quest_state(env, player, quest_id) {
+            states.push_back(state);
+        }
+    }
+    states
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{contract, contractimpl};
+
+    #[contract]
+    struct Stub;
+    #[contractimpl]
+    impl Stub {}
+
+    /// Quest state lives in contract storage, so test bodies run through
+    /// `Env::as_contract`. Each `run` is a separate invocation frame, matching
+    /// how the flow works in practice (start, progress, claim and branch are
+    /// distinct transactions) and satisfying the rule that `require_auth` may
+    /// only be met once per frame.
+    struct Fixture {
+        env: Env,
+        contract: Address,
+        author: Address,
+        player: Address,
+    }
+
+    impl Fixture {
+        fn run<T>(&self, f: impl FnOnce() -> T) -> T {
+            self.env.as_contract(&self.contract, f)
+        }
+    }
+
+    fn fixture() -> Fixture {
+        let f = bare_fixture();
+        let player = f.player.clone();
+        f.run(|| player_profile::initialize_profile(&f.env, player).unwrap());
+        f
+    }
+
+    /// Like [`fixture`] but the player has no profile, so rewards cannot land.
+    fn bare_fixture() -> Fixture {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = env.register(Stub, ());
+        let author = Address::generate(&env);
+        let player = Address::generate(&env);
+        Fixture {
+            env,
+            contract,
+            author,
+            player,
+        }
+    }
+
+    fn reward(essence: i128) -> QuestReward {
+        QuestReward {
+            essence,
+            resource_type: ResourceType::StellarDust,
+            resource_amount: 0,
+            xp: 10,
+            cosmetic_roll: false,
+        }
+    }
+
+    fn branch(env: &Env, choice_id: u32, label: &str, next: u64) -> QuestBranch {
+        QuestBranch {
+            choice_id,
+            label: Symbol::new(env, label),
+            next_quest_id: next,
+        }
+    }
+
+    fn branches(env: &Env, items: &[QuestBranch]) -> Vec<QuestBranch> {
+        let mut v = Vec::new(env);
+        for b in items {
+            v.push_back(b.clone());
+        }
+        v
+    }
+
+    /// Add a node with sensible defaults for the fields a test does not care
+    /// about, so call sites stay readable.
+    fn add_node(
+        f: &Fixture,
+        chain_id: u64,
+        objective: Symbol,
+        target: u32,
+        essence: i128,
+        node_branches: Vec<QuestBranch>,
+        duration_secs: u64,
+    ) -> Result<u64, QuestError> {
+        f.run(|| {
+            add_quest_node(
+                &f.env,
+                f.author.clone(),
+                chain_id,
+                objective,
+                target,
+                reward(essence),
+                symbol_short!("tier"),
+                String::from_str(&f.env, "Title"),
+                String::from_str(&f.env, "Description"),
+                node_branches,
+                duration_secs,
+            )
+        })
+    }
+
+    /// A three-node chain that branches after the root:
+    ///
+    /// ```text
+    ///   node1 ─┬─ choice 1 ─► node2 ─► (end)
+    ///          └─ choice 2 ─► node3 ─► (end)
+    /// ```
+    fn branching_chain(f: &Fixture) -> (u64, u64, u64, u64) {
+        let chain_id =
+            f.run(|| define_chain(&f.env, f.author.clone(), symbol_short!("prologue")).unwrap());
+
+        // The root is added first (that is what makes it the root) and carries
+        // forward references to nodes 2 and 3, which do not exist yet.
+        let node1 = add_node(
+            f,
+            chain_id,
+            symbol_short!("scan"),
+            3,
+            100,
+            branches(
+                &f.env,
+                &[branch(&f.env, 1, "ally", 2), branch(&f.env, 2, "raid", 3)],
+            ),
+            0,
+        )
+        .unwrap();
+
+        let node2 = add_node(
+            f,
+            chain_id,
+            symbol_short!("trade"),
+            2,
+            250,
+            branches(&f.env, &[branch(&f.env, 1, "finish", CHAIN_TERMINUS)]),
+            0,
+        )
+        .unwrap();
+
+        let node3 = add_node(
+            f,
+            chain_id,
+            symbol_short!("harvest"),
+            5,
+            400,
+            Vec::new(&f.env),
+            0,
+        )
+        .unwrap();
+
+        (chain_id, node1, node2, node3)
+    }
+
+    // ── Authoring ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn chain_records_its_root_and_node_count() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+
+        f.run(|| {
+            let chain = get_chain(&f.env, chain_id).unwrap();
+            assert_eq!(chain.root_quest_id, node1);
+            assert_eq!(chain.node_count, 3);
+            assert_eq!(chain.creator, f.author);
+        });
+    }
+
+    #[test]
+    fn node_step_indexes_follow_insertion_order() {
+        let f = fixture();
+        let (_, node1, node2, node3) = branching_chain(&f);
+
+        f.run(|| {
+            assert_eq!(get_quest_node(&f.env, node1).unwrap().step_index, 0);
+            assert_eq!(get_quest_node(&f.env, node2).unwrap().step_index, 1);
+            assert_eq!(get_quest_node(&f.env, node3).unwrap().step_index, 2);
+        });
+    }
+
+    #[test]
+    fn only_the_creator_may_extend_a_chain() {
+        let f = fixture();
+        let (chain_id, _, _, _) = branching_chain(&f);
+
+        let result = f.run(|| {
+            add_quest_node(
+                &f.env,
+                f.player.clone(),
+                chain_id,
+                symbol_short!("scan"),
+                1,
+                reward(1),
+                symbol_short!("tier"),
+                String::from_str(&f.env, "t"),
+                String::from_str(&f.env, "d"),
+                Vec::new(&f.env),
+                0,
+            )
+        });
+        assert_eq!(result, Err(QuestError::Unauthorized));
+    }
+
+    #[test]
+    fn node_rejects_zero_target_and_zero_choice_ids() {
+        let f = fixture();
+        let chain_id =
+            f.run(|| define_chain(&f.env, f.author.clone(), symbol_short!("c")).unwrap());
+
+        assert_eq!(
+            add_node(
+                &f,
+                chain_id,
+                symbol_short!("scan"),
+                0,
+                1,
+                Vec::new(&f.env),
+                0
+            ),
+            Err(QuestError::InvalidTarget)
+        );
+        assert_eq!(
+            add_node(
+                &f,
+                chain_id,
+                symbol_short!("scan"),
+                1,
+                1,
+                branches(&f.env, &[branch(&f.env, 0, "bad", CHAIN_TERMINUS)]),
+                0
+            ),
+            Err(QuestError::InvalidBranch)
+        );
+    }
+
+    #[test]
+    fn node_rejects_too_many_branches() {
+        let f = fixture();
+        let chain_id =
+            f.run(|| define_chain(&f.env, f.author.clone(), symbol_short!("c")).unwrap());
+
+        let mut too_many = Vec::new(&f.env);
+        for i in 1..=(MAX_BRANCHES_PER_NODE + 1) {
+            too_many.push_back(branch(&f.env, i, "b", CHAIN_TERMINUS));
+        }
+
+        assert_eq!(
+            add_node(&f, chain_id, symbol_short!("scan"), 1, 1, too_many, 0),
+            Err(QuestError::TooManyBranches)
+        );
+    }
+
+    #[test]
+    fn chain_length_is_capped() {
+        let f = fixture();
+        let chain_id =
+            f.run(|| define_chain(&f.env, f.author.clone(), symbol_short!("long")).unwrap());
+
+        for _ in 0..MAX_CHAIN_LENGTH {
+            add_node(
+                &f,
+                chain_id,
+                symbol_short!("scan"),
+                1,
+                1,
+                Vec::new(&f.env),
+                0,
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            add_node(
+                &f,
+                chain_id,
+                symbol_short!("scan"),
+                1,
+                1,
+                Vec::new(&f.env),
+                0
+            ),
+            Err(QuestError::ChainFull)
+        );
+    }
+
+    #[test]
+    fn adding_a_node_to_a_missing_chain_fails() {
+        let f = fixture();
+        assert_eq!(
+            add_node(&f, 999, symbol_short!("scan"), 1, 1, Vec::new(&f.env), 0),
+            Err(QuestError::ChainNotFound)
+        );
+    }
+
+    #[test]
+    fn validate_chain_accepts_a_complete_chain_and_rejects_dangling_edges() {
+        let f = fixture();
+        let (chain_id, _, _, _) = branching_chain(&f);
+        f.run(|| validate_chain(&f.env, chain_id).unwrap());
+
+        // A chain whose only node points at a node that was never authored.
+        let broken =
+            f.run(|| define_chain(&f.env, f.author.clone(), symbol_short!("broken")).unwrap());
+        add_node(
+            &f,
+            broken,
+            symbol_short!("scan"),
+            1,
+            1,
+            branches(&f.env, &[branch(&f.env, 1, "nowhere", 9_999)]),
+            0,
+        )
+        .unwrap();
+
+        f.run(|| {
+            assert_eq!(
+                validate_chain(&f.env, broken),
+                Err(QuestError::DanglingBranch)
+            );
+            assert_eq!(
+                validate_chain(&f.env, 12_345),
+                Err(QuestError::ChainNotFound)
+            );
+        });
+    }
+
+    // ── Starting ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn starting_a_chain_activates_the_root_node() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+
+        let state = f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        assert_eq!(state.quest_id, node1);
+        assert_eq!(state.status, QuestStatus::Active);
+        assert_eq!(state.target, 3);
+        assert_eq!(state.progress, 0);
+
+        f.run(|| {
+            assert_eq!(get_active_quests(&f.env, &f.player).len(), 1);
+            let progress = get_chain_progress(&f.env, &f.player, chain_id).unwrap();
+            assert_eq!(progress.current_quest_id, node1);
+            assert_eq!(progress.steps_completed, 0);
+            assert!(!progress.finished);
+        });
+    }
+
+    #[test]
+    fn a_chain_cannot_be_started_twice() {
+        let f = fixture();
+        let (chain_id, _, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+
+        f.run(|| {
+            assert_eq!(
+                start_chain(&f.env, f.player.clone(), chain_id),
+                Err(QuestError::ChainAlreadyStarted)
+            );
+        });
+    }
+
+    #[test]
+    fn starting_an_unknown_or_empty_chain_fails() {
+        let f = fixture();
+        f.run(|| {
+            assert_eq!(
+                start_chain(&f.env, f.player.clone(), 42),
+                Err(QuestError::ChainNotFound)
+            );
+        });
+
+        let empty =
+            f.run(|| define_chain(&f.env, f.author.clone(), symbol_short!("empty")).unwrap());
+        f.run(|| {
+            assert_eq!(
+                start_chain(&f.env, f.player.clone(), empty),
+                Err(QuestError::QuestNotFound)
+            );
+        });
+    }
+
+    #[test]
+    fn active_quests_are_capped_per_player() {
+        let f = fixture();
+
+        // Each single-node chain contributes one active quest.
+        for _ in 0..MAX_ACTIVE_QUESTS {
+            let chain_id =
+                f.run(|| define_chain(&f.env, f.author.clone(), symbol_short!("c")).unwrap());
+            add_node(
+                &f,
+                chain_id,
+                symbol_short!("scan"),
+                1,
+                1,
+                Vec::new(&f.env),
+                0,
+            )
+            .unwrap();
+            f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        }
+
+        let extra =
+            f.run(|| define_chain(&f.env, f.author.clone(), symbol_short!("extra")).unwrap());
+        add_node(&f, extra, symbol_short!("scan"), 1, 1, Vec::new(&f.env), 0).unwrap();
+        f.run(|| {
+            assert_eq!(
+                start_chain(&f.env, f.player.clone(), extra),
+                Err(QuestError::TooManyActiveQuests)
+            );
+        });
+    }
+
+    // ── Progress tracking ─────────────────────────────────────────────────
+
+    #[test]
+    fn progress_accumulates_then_completes_at_the_target() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+
+        let s1 = f.run(|| record_progress(&f.env, f.player.clone(), node1, 1).unwrap());
+        assert_eq!(s1.progress, 1);
+        assert_eq!(s1.status, QuestStatus::Active);
+
+        let s2 = f.run(|| record_progress(&f.env, f.player.clone(), node1, 2).unwrap());
+        assert_eq!(s2.progress, 3);
+        assert_eq!(s2.status, QuestStatus::Completed);
+        assert_eq!(s2.completed_at, f.env.ledger().timestamp());
+
+        // Completing removes the quest from the active list.
+        f.run(|| assert_eq!(get_active_quests(&f.env, &f.player).len(), 0));
+    }
+
+    #[test]
+    fn progress_is_clamped_to_the_target() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+
+        let state = f.run(|| record_progress(&f.env, f.player.clone(), node1, 99).unwrap());
+        assert_eq!(state.progress, 3, "progress never exceeds the target");
+    }
+
+    #[test]
+    fn progress_on_a_completed_quest_is_rejected() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+
+        f.run(|| {
+            assert_eq!(
+                record_progress(&f.env, f.player.clone(), node1, 1),
+                Err(QuestError::InvalidStatus)
+            );
+        });
+    }
+
+    #[test]
+    fn progress_on_an_unstarted_quest_is_rejected() {
+        let f = fixture();
+        let (_, node1, _, _) = branching_chain(&f);
+        f.run(|| {
+            assert_eq!(
+                record_progress(&f.env, f.player.clone(), node1, 1),
+                Err(QuestError::QuestNotStarted)
+            );
+        });
+    }
+
+    #[test]
+    fn a_quest_past_its_deadline_expires() {
+        let f = fixture();
+        let chain_id =
+            f.run(|| define_chain(&f.env, f.author.clone(), symbol_short!("timed")).unwrap());
+        let node = add_node(
+            &f,
+            chain_id,
+            symbol_short!("scan"),
+            5,
+            10,
+            Vec::new(&f.env),
+            3_600,
+        )
+        .unwrap();
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+
+        f.env.ledger().with_mut(|l| l.timestamp += 3_601);
+
+        f.run(|| {
+            assert_eq!(
+                record_progress(&f.env, f.player.clone(), node, 1),
+                Err(QuestError::QuestExpired)
+            );
+        });
+        f.run(|| {
+            let state = get_quest_state(&f.env, &f.player, node).unwrap();
+            assert_eq!(state.status, QuestStatus::Expired);
+            assert_eq!(get_active_quests(&f.env, &f.player).len(), 0);
+        });
+    }
+
+    // ── Rewards ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn claiming_pays_essence_and_marks_the_quest_claimed() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+
+        let before = f.run(|| {
+            player_profile::get_profile_by_owner(&f.env, &f.player)
+                .unwrap()
+                .essence_earned
+        });
+        let reward = f.run(|| claim_quest_reward(&f.env, f.player.clone(), node1).unwrap());
+        let after = f.run(|| {
+            player_profile::get_profile_by_owner(&f.env, &f.player)
+                .unwrap()
+                .essence_earned
+        });
+
+        assert_eq!(reward.essence, 100);
+        assert_eq!(after - before, 100);
+        f.run(|| {
+            assert_eq!(
+                get_quest_state(&f.env, &f.player, node1).unwrap().status,
+                QuestStatus::Claimed
+            );
+        });
+    }
+
+    #[test]
+    fn claiming_grants_resource_rewards() {
+        let f = fixture();
+        let chain_id =
+            f.run(|| define_chain(&f.env, f.author.clone(), symbol_short!("res")).unwrap());
+        let node = f
+            .run(|| {
+                add_quest_node(
+                    &f.env,
+                    f.author.clone(),
+                    chain_id,
+                    symbol_short!("harvest"),
+                    1,
+                    QuestReward {
+                        essence: 0,
+                        resource_type: ResourceType::DarkMatter,
+                        resource_amount: 75,
+                        xp: 5,
+                        cosmetic_roll: true,
+                    },
+                    symbol_short!("tier"),
+                    String::from_str(&f.env, "t"),
+                    String::from_str(&f.env, "d"),
+                    Vec::new(&f.env),
+                    0,
+                )
+            })
+            .unwrap();
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node, 1).unwrap());
+
+        let reward = f.run(|| claim_quest_reward(&f.env, f.player.clone(), node).unwrap());
+        assert!(reward.cosmetic_roll);
+        f.run(|| {
+            assert_eq!(
+                resource_minter::balance_of(&f.env, &f.player, &ResourceType::DarkMatter),
+                75
+            );
+        });
+    }
+
+    #[test]
+    fn a_reward_cannot_be_claimed_twice() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+        f.run(|| claim_quest_reward(&f.env, f.player.clone(), node1).unwrap());
+
+        f.run(|| {
+            assert_eq!(
+                claim_quest_reward(&f.env, f.player.clone(), node1),
+                Err(QuestError::AlreadyClaimed)
+            );
+        });
+    }
+
+    #[test]
+    fn an_incomplete_quest_cannot_be_claimed() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 1).unwrap());
+
+        f.run(|| {
+            assert_eq!(
+                claim_quest_reward(&f.env, f.player.clone(), node1),
+                Err(QuestError::InvalidStatus)
+            );
+        });
+    }
+
+    #[test]
+    fn a_player_without_a_profile_cannot_claim() {
+        let f = bare_fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+        f.run(|| {
+            assert_eq!(
+                claim_quest_reward(&f.env, f.player.clone(), node1),
+                Err(QuestError::ProfileNotFound)
+            );
+        });
+    }
+
+    // ── Branching narrative ───────────────────────────────────────────────
+
+    #[test]
+    fn choosing_a_branch_activates_the_successor_and_records_the_path() {
+        let f = fixture();
+        let (chain_id, node1, node2, _node3) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+        f.run(|| claim_quest_reward(&f.env, f.player.clone(), node1).unwrap());
+
+        let next = f
+            .run(|| choose_branch(&f.env, f.player.clone(), node1, 1).unwrap())
+            .expect("choice 1 has a successor");
+        assert_eq!(next.quest_id, node2);
+        assert_eq!(next.status, QuestStatus::Active);
+        assert_eq!(next.target, 2);
+
+        f.run(|| {
+            let progress = get_chain_progress(&f.env, &f.player, chain_id).unwrap();
+            assert_eq!(progress.current_quest_id, node2);
+            assert_eq!(progress.path.len(), 1);
+            assert_eq!(progress.path.get(0).unwrap(), 1);
+            assert_eq!(progress.steps_completed, 1);
+            assert_eq!(progress.total_essence_earned, 100);
+        });
+    }
+
+    #[test]
+    fn the_other_branch_leads_somewhere_else() {
+        let f = fixture();
+        let (chain_id, node1, _node2, node3) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+        f.run(|| claim_quest_reward(&f.env, f.player.clone(), node1).unwrap());
+
+        let next = f
+            .run(|| choose_branch(&f.env, f.player.clone(), node1, 2).unwrap())
+            .expect("choice 2 has a successor");
+        assert_eq!(next.quest_id, node3);
+        assert_eq!(next.target, 5);
+    }
+
+    #[test]
+    fn a_terminus_branch_finishes_the_chain() {
+        let f = fixture();
+        let (chain_id, node1, node2, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+        f.run(|| claim_quest_reward(&f.env, f.player.clone(), node1).unwrap());
+        f.run(|| choose_branch(&f.env, f.player.clone(), node1, 1).unwrap());
+
+        f.run(|| record_progress(&f.env, f.player.clone(), node2, 2).unwrap());
+        f.run(|| claim_quest_reward(&f.env, f.player.clone(), node2).unwrap());
+        let end = f.run(|| choose_branch(&f.env, f.player.clone(), node2, 1).unwrap());
+
+        assert!(end.is_none(), "a terminus branch has no successor");
+        f.run(|| {
+            let progress = get_chain_progress(&f.env, &f.player, chain_id).unwrap();
+            assert!(progress.finished);
+            assert_eq!(progress.steps_completed, 2);
+            assert_eq!(progress.total_essence_earned, 350);
+            assert_eq!(progress.path.len(), 2);
+        });
+    }
+
+    #[test]
+    fn a_branchless_node_finishes_the_chain_on_claim() {
+        let f = fixture();
+        let (chain_id, node1, _, node3) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+        f.run(|| claim_quest_reward(&f.env, f.player.clone(), node1).unwrap());
+        f.run(|| choose_branch(&f.env, f.player.clone(), node1, 2).unwrap());
+
+        f.run(|| record_progress(&f.env, f.player.clone(), node3, 5).unwrap());
+        f.run(|| claim_quest_reward(&f.env, f.player.clone(), node3).unwrap());
+
+        f.run(|| {
+            let progress = get_chain_progress(&f.env, &f.player, chain_id).unwrap();
+            assert!(progress.finished, "node3 has no branches, so the path ends");
+            assert_eq!(progress.total_essence_earned, 500);
+        });
+    }
+
+    #[test]
+    fn branching_before_claiming_is_rejected() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+
+        f.run(|| {
+            assert_eq!(
+                choose_branch(&f.env, f.player.clone(), node1, 1),
+                Err(QuestError::InvalidStatus)
+            );
+        });
+    }
+
+    #[test]
+    fn a_branch_cannot_be_taken_twice() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+        f.run(|| claim_quest_reward(&f.env, f.player.clone(), node1).unwrap());
+        f.run(|| choose_branch(&f.env, f.player.clone(), node1, 1).unwrap());
+
+        f.run(|| {
+            assert_eq!(
+                choose_branch(&f.env, f.player.clone(), node1, 2),
+                Err(QuestError::InvalidStatus),
+                "the narrative path is immutable once walked"
+            );
+        });
+    }
+
+    #[test]
+    fn an_unknown_choice_is_rejected() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+        f.run(|| record_progress(&f.env, f.player.clone(), node1, 3).unwrap());
+        f.run(|| claim_quest_reward(&f.env, f.player.clone(), node1).unwrap());
+
+        f.run(|| {
+            assert_eq!(
+                choose_branch(&f.env, f.player.clone(), node1, 99),
+                Err(QuestError::InvalidBranch)
+            );
+        });
+    }
+
+    // ── Mission bridge ────────────────────────────────────────────────────
+
+    #[test]
+    fn mission_completion_advances_matching_quests_only() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+
+        // node1's objective is `scan`; a `trade` mission must not advance it.
+        f.run(|| {
+            assert_eq!(
+                on_mission_completed(&f.env, &f.player, symbol_short!("trade"), 1),
+                0
+            );
+            assert_eq!(
+                get_quest_state(&f.env, &f.player, node1).unwrap().progress,
+                0
+            );
+        });
+
+        f.run(|| {
+            assert_eq!(
+                on_mission_completed(&f.env, &f.player, symbol_short!("scan"), 2),
+                1
+            );
+            assert_eq!(
+                get_quest_state(&f.env, &f.player, node1).unwrap().progress,
+                2
+            );
+        });
+    }
+
+    #[test]
+    fn mission_completion_can_finish_a_quest() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+
+        f.run(|| on_mission_completed(&f.env, &f.player, symbol_short!("scan"), 3));
+        f.run(|| {
+            assert_eq!(
+                get_quest_state(&f.env, &f.player, node1).unwrap().status,
+                QuestStatus::Completed
+            );
+        });
+    }
+
+    #[test]
+    fn mission_completion_is_a_no_op_for_a_player_with_no_quests() {
+        let f = fixture();
+        f.run(|| {
+            assert_eq!(
+                on_mission_completed(&f.env, &f.player, symbol_short!("scan"), 5),
+                0
+            );
+        });
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn active_quest_states_are_listed() {
+        let f = fixture();
+        let (chain_id, node1, _, _) = branching_chain(&f);
+        f.run(|| start_chain(&f.env, f.player.clone(), chain_id).unwrap());
+
+        f.run(|| {
+            let states = get_active_quest_states(&f.env, &f.player);
+            assert_eq!(states.len(), 1);
+            assert_eq!(states.get(0).unwrap().quest_id, node1);
+        });
+    }
+
+    #[test]
+    fn queries_return_none_for_unknown_ids() {
+        let f = fixture();
+        f.run(|| {
+            assert!(get_chain(&f.env, 1).is_none());
+            assert!(get_quest_node(&f.env, 1).is_none());
+            assert!(get_quest_state(&f.env, &f.player, 1).is_none());
+            assert!(get_chain_progress(&f.env, &f.player, 1).is_none());
+            assert_eq!(get_active_quests(&f.env, &f.player).len(), 0);
+        });
+    }
+}

--- a/src/resource_minter.rs
+++ b/src/resource_minter.rs
@@ -55,6 +55,10 @@ pub struct ResourceRecord {
 pub enum MinterKey {
     Balance(Address, ResourceType),
     TotalSupply(ResourceType),
+    /// Cumulative amount ever minted, never decremented. Together with the
+    /// burn counters in [`crate::token_burning`] this gives the deflation rate
+    /// (Issue #281): `burned / ever_minted`.
+    TotalMinted(ResourceType),
 }
 
 // ── Error ─────────────────────────────────────────────────────
@@ -72,6 +76,8 @@ pub enum MinterError {
     NoResourceAtAnomaly = 203,
     /// A checked arithmetic operation overflowed (Issue #239).
     ArithmeticOverflow = 204,
+    /// The account holds less than the requested debit amount (Issue #281).
+    InsufficientBalance = 205,
 }
 
 impl From<RateLimitError> for MinterError {
@@ -130,6 +136,17 @@ impl ResourceMinterContract {
             .ok_or(MinterError::ArithmeticOverflow)?;
         env.storage().persistent().set(&supply_key, &new_supply);
 
+        // ── Cumulative mint counter (Issue #281) ───────────────
+        // Unlike TotalSupply this is monotonic — burning reduces supply but
+        // never the historical mint total, which is the denominator of the
+        // deflation rate.
+        let minted_key = MinterKey::TotalMinted(resource_type.clone());
+        let minted: u64 = env.storage().persistent().get(&minted_key).unwrap_or(0);
+        let new_minted = minted
+            .checked_add(amount)
+            .ok_or(MinterError::ArithmeticOverflow)?;
+        env.storage().persistent().set(&minted_key, &new_minted);
+
         let record = ResourceRecord {
             owner: caller.clone(),
             resource_type: resource_type.clone(),
@@ -161,6 +178,167 @@ impl ResourceMinterContract {
             .get(&MinterKey::TotalSupply(resource_type))
             .unwrap_or(0)
     }
+
+    /// Cumulative amount ever minted for `resource_type`, ignoring burns.
+    pub fn total_minted(env: &Env, resource_type: ResourceType) -> u64 {
+        self::total_minted(env, &resource_type)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Supply-reducing primitives (Issue #281)
+// ─────────────────────────────────────────────────────────────
+//
+// `token_burning` is the only intended caller. Keeping these here rather than
+// in the burning module means the balance and supply ledgers stay owned by a
+// single module, so every credit and debit goes through the same checked
+// arithmetic.
+
+/// Read a holder's balance without going through the contract entrypoint.
+pub fn balance_of(env: &Env, owner: &Address, resource_type: &ResourceType) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&MinterKey::Balance(owner.clone(), resource_type.clone()))
+        .unwrap_or(0)
+}
+
+/// Cumulative amount ever minted for `resource_type`.
+pub fn total_minted(env: &Env, resource_type: &ResourceType) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&MinterKey::TotalMinted(resource_type.clone()))
+        .unwrap_or(0)
+}
+
+/// Current circulating supply for `resource_type`.
+pub fn circulating_supply(env: &Env, resource_type: &ResourceType) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&MinterKey::TotalSupply(resource_type.clone()))
+        .unwrap_or(0)
+}
+
+/// Debit `amount` from `owner`'s balance.
+///
+/// Does **not** require auth — the caller is responsible for having authorized
+/// the holder. Returns the new balance, or `InsufficientBalance` if the debit
+/// would go negative (checked, never wrapping).
+pub fn debit_balance(
+    env: &Env,
+    owner: &Address,
+    resource_type: &ResourceType,
+    amount: u64,
+) -> Result<u64, MinterError> {
+    if amount == 0 {
+        return Err(MinterError::InvalidAmount);
+    }
+
+    let key = MinterKey::Balance(owner.clone(), resource_type.clone());
+    let current: u64 = env.storage().persistent().get(&key).unwrap_or(0);
+    let new_balance = current
+        .checked_sub(amount)
+        .ok_or(MinterError::InsufficientBalance)?;
+    env.storage().persistent().set(&key, &new_balance);
+
+    Ok(new_balance)
+}
+
+/// Reduce the circulating supply of `resource_type` by `amount`.
+///
+/// Returns the new supply. Underflow is treated as `InsufficientBalance`: it
+/// would mean the supply ledger disagreed with the sum of balances, and
+/// silently saturating there would hide the inconsistency.
+pub fn reduce_supply(
+    env: &Env,
+    resource_type: &ResourceType,
+    amount: u64,
+) -> Result<u64, MinterError> {
+    let key = MinterKey::TotalSupply(resource_type.clone());
+    let supply: u64 = env.storage().persistent().get(&key).unwrap_or(0);
+    let new_supply = supply
+        .checked_sub(amount)
+        .ok_or(MinterError::InsufficientBalance)?;
+    env.storage().persistent().set(&key, &new_supply);
+
+    Ok(new_supply)
+}
+
+/// Move `amount` between two holders without touching supply counters.
+///
+/// A transfer is not a mint or a burn, so neither `TotalSupply` nor
+/// `TotalMinted` changes — only the two balances do.
+pub fn move_balance(
+    env: &Env,
+    from: &Address,
+    to: &Address,
+    resource_type: &ResourceType,
+    amount: u64,
+) -> Result<u64, MinterError> {
+    if amount == 0 {
+        return Err(MinterError::InvalidAmount);
+    }
+    if from == to {
+        return Ok(balance_of(env, from, resource_type));
+    }
+
+    let from_key = MinterKey::Balance(from.clone(), resource_type.clone());
+    let from_balance: u64 = env.storage().persistent().get(&from_key).unwrap_or(0);
+    let remaining = from_balance
+        .checked_sub(amount)
+        .ok_or(MinterError::InsufficientBalance)?;
+
+    let to_key = MinterKey::Balance(to.clone(), resource_type.clone());
+    let to_balance: u64 = env.storage().persistent().get(&to_key).unwrap_or(0);
+    let credited = to_balance
+        .checked_add(amount)
+        .ok_or(MinterError::ArithmeticOverflow)?;
+
+    env.storage().persistent().set(&from_key, &remaining);
+    env.storage().persistent().set(&to_key, &credited);
+
+    Ok(credited)
+}
+
+/// Credit `amount` to `owner` without auth or rate limiting.
+///
+/// Test- and reward-path helper: used by the burn tests to seed balances and by
+/// reward subsystems that grant resources they have already authorized.
+pub fn credit_balance(
+    env: &Env,
+    owner: &Address,
+    resource_type: &ResourceType,
+    amount: u64,
+) -> Result<u64, MinterError> {
+    if amount == 0 {
+        return Err(MinterError::InvalidAmount);
+    }
+
+    let key = MinterKey::Balance(owner.clone(), resource_type.clone());
+    let current: u64 = env.storage().persistent().get(&key).unwrap_or(0);
+    let new_balance = current
+        .checked_add(amount)
+        .ok_or(MinterError::ArithmeticOverflow)?;
+    env.storage().persistent().set(&key, &new_balance);
+
+    let supply_key = MinterKey::TotalSupply(resource_type.clone());
+    let supply: u64 = env.storage().persistent().get(&supply_key).unwrap_or(0);
+    env.storage().persistent().set(
+        &supply_key,
+        &supply
+            .checked_add(amount)
+            .ok_or(MinterError::ArithmeticOverflow)?,
+    );
+
+    let minted_key = MinterKey::TotalMinted(resource_type.clone());
+    let minted: u64 = env.storage().persistent().get(&minted_key).unwrap_or(0);
+    env.storage().persistent().set(
+        &minted_key,
+        &minted
+            .checked_add(amount)
+            .ok_or(MinterError::ArithmeticOverflow)?,
+    );
+
+    Ok(new_balance)
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -245,5 +423,169 @@ mod tests {
             1,
         );
         assert_eq!(result, Err(MinterError::RateLimitExceeded));
+    }
+
+    // ── Supply-reducing primitives (Issue #281) ─────────────────
+    //
+    // These touch the balance and supply ledgers, so — unlike the pure
+    // arithmetic tests above — they must run inside a contract invocation.
+    mod supply_primitives {
+        use super::*;
+        use soroban_sdk::contractimpl;
+
+        #[contract]
+        struct Stub;
+        #[contractimpl]
+        impl Stub {}
+
+        fn in_contract<T>(f: impl FnOnce(&Env) -> T) -> T {
+            let env = make_env();
+            let contract = env.register(Stub, ());
+            env.as_contract(&contract, || f(&env))
+        }
+
+        #[test]
+        fn credit_updates_balance_supply_and_mint_total() {
+            in_contract(|env| {
+                let holder = Address::generate(env);
+                let rt = ResourceType::DarkMatter;
+
+                assert_eq!(credit_balance(env, &holder, &rt, 400).unwrap(), 400);
+                assert_eq!(balance_of(env, &holder, &rt), 400);
+                assert_eq!(circulating_supply(env, &rt), 400);
+                assert_eq!(total_minted(env, &rt), 400);
+            });
+        }
+
+        #[test]
+        fn debit_reduces_balance_but_not_the_mint_total() {
+            in_contract(|env| {
+                let holder = Address::generate(env);
+                let rt = ResourceType::StellarDust;
+                credit_balance(env, &holder, &rt, 100).unwrap();
+
+                assert_eq!(debit_balance(env, &holder, &rt, 40).unwrap(), 60);
+                assert_eq!(reduce_supply(env, &rt, 40).unwrap(), 60);
+                assert_eq!(
+                    total_minted(env, &rt),
+                    100,
+                    "the historical mint total must be monotonic"
+                );
+            });
+        }
+
+        #[test]
+        fn debit_beyond_balance_is_rejected_without_wrapping() {
+            in_contract(|env| {
+                let holder = Address::generate(env);
+                let rt = ResourceType::StellarDust;
+                credit_balance(env, &holder, &rt, 10).unwrap();
+
+                assert_eq!(
+                    debit_balance(env, &holder, &rt, 11),
+                    Err(MinterError::InsufficientBalance)
+                );
+                assert_eq!(balance_of(env, &holder, &rt), 10, "balance is unchanged");
+            });
+        }
+
+        #[test]
+        fn reduce_supply_beyond_supply_is_rejected() {
+            in_contract(|env| {
+                assert_eq!(
+                    reduce_supply(env, &ResourceType::ExoticMatter, 1),
+                    Err(MinterError::InsufficientBalance)
+                );
+            });
+        }
+
+        #[test]
+        fn zero_amount_transfers_are_rejected() {
+            in_contract(|env| {
+                let holder = Address::generate(env);
+                let rt = ResourceType::StellarDust;
+
+                assert_eq!(
+                    credit_balance(env, &holder, &rt, 0),
+                    Err(MinterError::InvalidAmount)
+                );
+                assert_eq!(
+                    debit_balance(env, &holder, &rt, 0),
+                    Err(MinterError::InvalidAmount)
+                );
+            });
+        }
+
+        #[test]
+        fn credit_detects_balance_overflow() {
+            in_contract(|env| {
+                let holder = Address::generate(env);
+                let rt = ResourceType::StellarDust;
+                credit_balance(env, &holder, &rt, u64::MAX).unwrap();
+
+                assert_eq!(
+                    credit_balance(env, &holder, &rt, 1),
+                    Err(MinterError::ArithmeticOverflow)
+                );
+            });
+        }
+
+        #[test]
+        fn balances_are_tracked_per_resource_type() {
+            in_contract(|env| {
+                let holder = Address::generate(env);
+                credit_balance(env, &holder, &ResourceType::StellarDust, 10).unwrap();
+                credit_balance(env, &holder, &ResourceType::DarkMatter, 20).unwrap();
+
+                assert_eq!(balance_of(env, &holder, &ResourceType::StellarDust), 10);
+                assert_eq!(balance_of(env, &holder, &ResourceType::DarkMatter), 20);
+                assert_eq!(balance_of(env, &holder, &ResourceType::ExoticMatter), 0);
+            });
+        }
+
+        #[test]
+        fn move_balance_shifts_holdings_without_changing_supply() {
+            in_contract(|env| {
+                let from = Address::generate(env);
+                let to = Address::generate(env);
+                let rt = ResourceType::DarkMatter;
+                credit_balance(env, &from, &rt, 500).unwrap();
+
+                assert_eq!(move_balance(env, &from, &to, &rt, 200).unwrap(), 200);
+                assert_eq!(balance_of(env, &from, &rt), 300);
+                assert_eq!(balance_of(env, &to, &rt), 200);
+                assert_eq!(circulating_supply(env, &rt), 500, "a move is not a mint");
+                assert_eq!(total_minted(env, &rt), 500);
+            });
+        }
+
+        #[test]
+        fn move_balance_rejects_an_underfunded_sender() {
+            in_contract(|env| {
+                let from = Address::generate(env);
+                let to = Address::generate(env);
+                let rt = ResourceType::DarkMatter;
+                credit_balance(env, &from, &rt, 10).unwrap();
+
+                assert_eq!(
+                    move_balance(env, &from, &to, &rt, 11),
+                    Err(MinterError::InsufficientBalance)
+                );
+                assert_eq!(balance_of(env, &from, &rt), 10);
+                assert_eq!(balance_of(env, &to, &rt), 0);
+            });
+        }
+
+        #[test]
+        fn move_balance_to_self_is_a_no_op() {
+            in_contract(|env| {
+                let holder = Address::generate(env);
+                let rt = ResourceType::DarkMatter;
+                credit_balance(env, &holder, &rt, 100).unwrap();
+
+                assert_eq!(move_balance(env, &holder, &holder, &rt, 50).unwrap(), 100);
+                assert_eq!(balance_of(env, &holder, &rt), 100);
+            });
+        }
     }
 }

--- a/src/ship_customization.rs
+++ b/src/ship_customization.rs
@@ -23,7 +23,7 @@ pub enum SkinRarity {
 }
 
 #[contracttype]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ShipSkin {
     pub skin_id: u64,
     pub owner: Address,
@@ -156,6 +156,95 @@ pub fn transfer_skin(env: &Env, skin_id: u64, new_owner: &Address) -> Result<Shi
     Ok(skin)
 }
 
+// ─── Marketplace hooks (Issue #283) ───────────────────────────────────────────
+//
+// The cosmetic marketplace in `crate::nft_marketplace` needs to read a skin,
+// escrow it while listed, and hand it to a buyer. Those operations bypass the
+// owner-auth check in `transfer_skin` because consent was established when the
+// seller authorized the listing, so they stay crate-private.
+
+/// Fetch a minted skin by ID.
+pub fn get_skin(env: &Env, skin_id: u64) -> Option<ShipSkin> {
+    env.storage().persistent().get(&SkinKey::Skin(skin_id))
+}
+
+/// Toggle a skin's `tradeable` flag.
+///
+/// The marketplace clears it while a skin is listed, so the same cosmetic
+/// cannot be sold twice or transferred out from under an open listing.
+pub(crate) fn set_tradeable(
+    env: &Env,
+    skin_id: u64,
+    tradeable: bool,
+) -> Result<ShipSkin, SkinError> {
+    let mut skin: ShipSkin = env
+        .storage()
+        .persistent()
+        .get(&SkinKey::Skin(skin_id))
+        .ok_or(SkinError::SkinNotFound)?;
+
+    skin.tradeable = tradeable;
+    env.storage().persistent().set(&SkinKey::Skin(skin_id), &skin);
+
+    Ok(skin)
+}
+
+/// Move a skin to `new_owner` without requiring the current owner's auth, and
+/// keep both owners' skin lists consistent.
+pub(crate) fn transfer_skin_internal(
+    env: &Env,
+    skin_id: u64,
+    new_owner: &Address,
+) -> Result<ShipSkin, SkinError> {
+    let mut skin: ShipSkin = env
+        .storage()
+        .persistent()
+        .get(&SkinKey::Skin(skin_id))
+        .ok_or(SkinError::SkinNotFound)?;
+
+    let old_owner = skin.owner.clone();
+    if old_owner == *new_owner {
+        return Ok(skin);
+    }
+
+    skin.owner = new_owner.clone();
+    env.storage().persistent().set(&SkinKey::Skin(skin_id), &skin);
+
+    // Drop the ID from the seller's list …
+    let seller_skins: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&SkinKey::OwnerSkins(old_owner.clone()))
+        .unwrap_or_else(|| Vec::new(env));
+    let mut remaining = Vec::new(env);
+    for id in seller_skins.iter() {
+        if id != skin_id {
+            remaining.push_back(id);
+        }
+    }
+    env.storage()
+        .persistent()
+        .set(&SkinKey::OwnerSkins(old_owner.clone()), &remaining);
+
+    // … and add it to the buyer's.
+    let mut buyer_skins: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&SkinKey::OwnerSkins(new_owner.clone()))
+        .unwrap_or_else(|| Vec::new(env));
+    buyer_skins.push_back(skin_id);
+    env.storage()
+        .persistent()
+        .set(&SkinKey::OwnerSkins(new_owner.clone()), &buyer_skins);
+
+    env.events().publish(
+        (symbol_short!("skin"), symbol_short!("mktxfer")),
+        (skin_id, old_owner, new_owner.clone()),
+    );
+
+    Ok(skin)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,5 +295,108 @@ mod tests {
         
         let transferred = transfer_skin(&env, skin.skin_id, &new_owner).unwrap();
         assert_eq!(transferred.owner, new_owner);
+    }
+
+    // ── Marketplace hooks (Issue #283) ────────────────────────────────────
+    //
+    // Skin state lives in contract storage, so these run inside a contract
+    // invocation via `Env::as_contract`.
+
+    use soroban_sdk::{contract, contractimpl};
+
+    #[contract]
+    struct Stub;
+    #[contractimpl]
+    impl Stub {}
+
+    fn in_contract<T>(f: impl FnOnce(&Env) -> T) -> T {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = env.register(Stub, ());
+        env.as_contract(&contract, || f(&env))
+    }
+
+    fn mint_test_skin(env: &Env, owner: &Address) -> ShipSkin {
+        mint_skin(
+            env,
+            owner,
+            symbol_short!("void"),
+            SkinRarity::Legendary,
+            0x000000,
+            0x8800FF,
+            Bytes::new(env),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn get_skin_resolves_minted_cosmetics() {
+        in_contract(|env| {
+            let owner = Address::generate(env);
+            let skin = mint_test_skin(env, &owner);
+
+            assert_eq!(get_skin(env, skin.skin_id).unwrap().owner, owner);
+            assert!(get_skin(env, 999).is_none());
+        });
+    }
+
+    #[test]
+    fn set_tradeable_locks_and_unlocks_a_skin() {
+        in_contract(|env| {
+            let owner = Address::generate(env);
+            let skin = mint_test_skin(env, &owner);
+
+            assert!(!set_tradeable(env, skin.skin_id, false).unwrap().tradeable);
+            // A locked skin cannot be transferred by its owner.
+            let other = Address::generate(env);
+            assert_eq!(
+                transfer_skin(env, skin.skin_id, &other),
+                Err(SkinError::AlreadyApplied)
+            );
+
+            assert!(set_tradeable(env, skin.skin_id, true).unwrap().tradeable);
+            assert_eq!(set_tradeable(env, 999, false), Err(SkinError::SkinNotFound));
+        });
+    }
+
+    #[test]
+    fn internal_transfer_moves_the_skin_between_owner_lists() {
+        in_contract(|env| {
+            let seller = Address::generate(env);
+            let buyer = Address::generate(env);
+            let skin = mint_test_skin(env, &seller);
+
+            let moved = transfer_skin_internal(env, skin.skin_id, &buyer).unwrap();
+            assert_eq!(moved.owner, buyer);
+            assert_eq!(get_owner_skins(env, &seller).len(), 0);
+            assert_eq!(get_owner_skins(env, &buyer).len(), 1);
+            assert_eq!(get_owner_skins(env, &buyer).get(0).unwrap(), skin.skin_id);
+        });
+    }
+
+    #[test]
+    fn internal_transfer_to_the_current_owner_is_a_no_op() {
+        in_contract(|env| {
+            let owner = Address::generate(env);
+            let skin = mint_test_skin(env, &owner);
+
+            transfer_skin_internal(env, skin.skin_id, &owner).unwrap();
+            assert_eq!(
+                get_owner_skins(env, &owner).len(),
+                1,
+                "the skin must not be duplicated in the owner's list"
+            );
+        });
+    }
+
+    #[test]
+    fn internal_transfer_of_an_unknown_skin_fails() {
+        in_contract(|env| {
+            let buyer = Address::generate(env);
+            assert_eq!(
+                transfer_skin_internal(env, 42, &buyer),
+                Err(SkinError::SkinNotFound)
+            );
+        });
     }
 }

--- a/src/skins.rs
+++ b/src/skins.rs
@@ -1,7 +1,28 @@
-//! Predefined skin templates and marketplace
+//! Predefined skin templates, rarity model and preview rendering.
+//!
+//! The template catalogue below is the source of truth for what a cosmetic is
+//! worth and how often it should appear. Issue #283 adds three things on top of
+//! it:
+//!
+//!   * a **rarity system** — floor prices and drop weights per tier, plus
+//!     [`roll_rarity`] for weighted rolls;
+//!   * **preview functionality** — [`preview_template`] and [`preview_skin`]
+//!     return everything a client needs to render a cosmetic (derived accent,
+//!     gradient strip, effect layers, thumbnail seed) without owning it and
+//!     without mutating state;
+//!   * the pricing floor the cosmetic marketplace in
+//!     [`crate::nft_marketplace`] enforces on every listing.
 
+use crate::ship_customization::{ShipSkin, SkinRarity};
 use soroban_sdk::{contracttype, symbol_short, Bytes, Env, Symbol, Vec};
-use crate::ship_customization::{SkinRarity, ShipSkin};
+
+// ─── Rarity model ─────────────────────────────────────────────────────────────
+
+/// Basis-point denominator for drop weights.
+pub const RARITY_WEIGHT_DENOMINATOR: u32 = 10_000;
+
+/// Number of gradient stops in a [`SkinPreview`].
+pub const PREVIEW_GRADIENT_STOPS: u32 = 5;
 
 #[contracttype]
 #[derive(Clone)]
@@ -11,6 +32,45 @@ pub struct SkinTemplate {
     pub color_primary: u32,
     pub color_secondary: u32,
     pub price: i128,
+}
+
+/// Everything needed to render a cosmetic without owning it.
+///
+/// Pure function of the template (or minted skin) — safe to call from
+/// read-only endpoints and cheap enough to batch for a gallery view.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SkinPreview {
+    pub name: Symbol,
+    pub rarity: SkinRarity,
+    pub color_primary: u32,
+    pub color_secondary: u32,
+    /// Midpoint of the two base colours, for outlines and UI chrome.
+    pub color_accent: u32,
+    /// [`PREVIEW_GRADIENT_STOPS`] colours from primary to secondary.
+    pub gradient: Vec<u32>,
+    /// Visual effect layers the rarity unlocks (0 for Common … 3 for
+    /// Legendary). The client maps these onto shader passes.
+    pub effect_layers: u32,
+    /// Lowest price the cosmetic marketplace will accept for this rarity.
+    pub floor_price: i128,
+    /// How often the rarity drops, in basis points out of
+    /// [`RARITY_WEIGHT_DENOMINATOR`].
+    pub drop_weight_bps: u32,
+    /// Deterministic 8-byte seed for the client-side thumbnail generator, so
+    /// the same cosmetic always renders identically across sessions.
+    pub thumbnail_seed: Bytes,
+}
+
+/// Catalogue composition, for balance dashboards.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SkinRarityStats {
+    pub common: u32,
+    pub rare: u32,
+    pub epic: u32,
+    pub legendary: u32,
+    pub total: u32,
 }
 
 /// Get all available skin templates
@@ -378,6 +438,190 @@ pub fn get_skin_templates(env: &Env) -> Vec<SkinTemplate> {
     templates
 }
 
+// ─── Rarity system (Issue #283) ───────────────────────────────────────────────
+
+/// Lowest price the cosmetic marketplace accepts for `rarity`.
+///
+/// Matches the catalogue's mint price, so a cosmetic can never be resold below
+/// what it cost to create — that floor is what keeps the secondary market from
+/// undercutting the primary one.
+pub fn rarity_floor_price(rarity: &SkinRarity) -> i128 {
+    match rarity {
+        SkinRarity::Common => 100,
+        SkinRarity::Rare => 500,
+        SkinRarity::Epic => 2_000,
+        SkinRarity::Legendary => 10_000,
+    }
+}
+
+/// Drop weight for `rarity`, in basis points out of
+/// [`RARITY_WEIGHT_DENOMINATOR`]. The four weights sum to exactly the
+/// denominator, which [`roll_rarity`] relies on.
+pub fn rarity_drop_weight_bps(rarity: &SkinRarity) -> u32 {
+    match rarity {
+        SkinRarity::Common => 6_000,
+        SkinRarity::Rare => 3_000,
+        SkinRarity::Epic => 900,
+        SkinRarity::Legendary => 100,
+    }
+}
+
+/// Number of visual effect layers `rarity` unlocks.
+pub fn rarity_effect_layers(rarity: &SkinRarity) -> u32 {
+    match rarity {
+        SkinRarity::Common => 0,
+        SkinRarity::Rare => 1,
+        SkinRarity::Epic => 2,
+        SkinRarity::Legendary => 3,
+    }
+}
+
+/// Pick a rarity from `seed` using the weights in [`rarity_drop_weight_bps`].
+///
+/// Deterministic: the same seed always yields the same rarity, so a caller can
+/// derive a roll from any on-chain entropy source and have it be verifiable.
+pub fn roll_rarity(seed: u64) -> SkinRarity {
+    let roll = (seed % RARITY_WEIGHT_DENOMINATOR as u64) as u32;
+
+    let common = rarity_drop_weight_bps(&SkinRarity::Common);
+    let rare = common + rarity_drop_weight_bps(&SkinRarity::Rare);
+    let epic = rare + rarity_drop_weight_bps(&SkinRarity::Epic);
+
+    if roll < common {
+        SkinRarity::Common
+    } else if roll < rare {
+        SkinRarity::Rare
+    } else if roll < epic {
+        SkinRarity::Epic
+    } else {
+        SkinRarity::Legendary
+    }
+}
+
+/// Composition of the template catalogue by rarity.
+pub fn get_rarity_stats(env: &Env) -> SkinRarityStats {
+    let templates = get_skin_templates(env);
+    let mut stats = SkinRarityStats {
+        common: 0,
+        rare: 0,
+        epic: 0,
+        legendary: 0,
+        total: templates.len(),
+    };
+
+    for template in templates.iter() {
+        match template.rarity {
+            SkinRarity::Common => stats.common += 1,
+            SkinRarity::Rare => stats.rare += 1,
+            SkinRarity::Epic => stats.epic += 1,
+            SkinRarity::Legendary => stats.legendary += 1,
+        }
+    }
+
+    stats
+}
+
+/// Look up a template by its `name` symbol.
+pub fn get_template(env: &Env, name: Symbol) -> Option<SkinTemplate> {
+    get_skin_templates(env)
+        .iter()
+        .find(|t| t.name == name)
+}
+
+/// All templates of one rarity tier.
+pub fn get_templates_by_rarity(env: &Env, rarity: SkinRarity) -> Vec<SkinTemplate> {
+    let mut matching = Vec::new(env);
+    for template in get_skin_templates(env).iter() {
+        if template.rarity == rarity {
+            matching.push_back(template);
+        }
+    }
+    matching
+}
+
+// ─── Preview rendering (Issue #283) ───────────────────────────────────────────
+
+/// One channel of a linear interpolation between two packed RGB colours.
+fn lerp_channel(from: u32, to: u32, shift: u32, step: u32, steps: u32) -> u32 {
+    let a = ((from >> shift) & 0xFF) as i64;
+    let b = ((to >> shift) & 0xFF) as i64;
+    let value = a + ((b - a) * step as i64) / steps as i64;
+    ((value as u32) & 0xFF) << shift
+}
+
+/// Interpolate `step/steps` of the way from `from` to `to`.
+fn lerp_color(from: u32, to: u32, step: u32, steps: u32) -> u32 {
+    lerp_channel(from, to, 16, step, steps)
+        | lerp_channel(from, to, 8, step, steps)
+        | lerp_channel(from, to, 0, step, steps)
+}
+
+/// Build the preview payload for an arbitrary colour pair and rarity.
+///
+/// Shared by [`preview_template`] and [`preview_skin`] so a catalogue entry and
+/// a minted NFT of the same cosmetic always preview identically.
+pub fn build_preview(
+    env: &Env,
+    name: Symbol,
+    rarity: SkinRarity,
+    color_primary: u32,
+    color_secondary: u32,
+) -> SkinPreview {
+    let mut gradient = Vec::new(env);
+    let last_stop = PREVIEW_GRADIENT_STOPS - 1;
+    for step in 0..PREVIEW_GRADIENT_STOPS {
+        gradient.push_back(lerp_color(
+            color_primary,
+            color_secondary,
+            step,
+            last_stop,
+        ));
+    }
+
+    // The seed mixes both colours and the rarity's layer count so visually
+    // distinct cosmetics never collide on the same thumbnail.
+    let mix = (color_primary as u64) << 32
+        | (color_secondary as u64 ^ (rarity_effect_layers(&rarity) as u64) << 24);
+    let thumbnail_seed = Bytes::from_array(env, &mix.to_be_bytes());
+
+    SkinPreview {
+        name,
+        color_primary,
+        color_secondary,
+        color_accent: lerp_color(color_primary, color_secondary, 1, 2),
+        gradient,
+        effect_layers: rarity_effect_layers(&rarity),
+        floor_price: rarity_floor_price(&rarity),
+        drop_weight_bps: rarity_drop_weight_bps(&rarity),
+        rarity,
+        thumbnail_seed,
+    }
+}
+
+/// Preview a catalogue template by name, before buying or minting it.
+pub fn preview_template(env: &Env, name: Symbol) -> Option<SkinPreview> {
+    let template = get_template(env, name)?;
+    Some(build_preview(
+        env,
+        template.name,
+        template.rarity,
+        template.color_primary,
+        template.color_secondary,
+    ))
+}
+
+/// Preview a minted skin NFT — the same payload as [`preview_template`], but
+/// resolved from on-chain skin state so marketplace listings can be rendered.
+pub fn preview_skin(env: &Env, skin: &ShipSkin) -> SkinPreview {
+    build_preview(
+        env,
+        skin.name.clone(),
+        skin.rarity.clone(),
+        skin.color_primary,
+        skin.color_secondary,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -393,7 +637,7 @@ mod tests {
     fn test_rarity_pricing() {
         let env = Env::default();
         let templates = get_skin_templates(&env);
-        
+
         for i in 0..templates.len() {
             let t = templates.get(i).unwrap();
             match t.rarity {
@@ -403,5 +647,231 @@ mod tests {
                 SkinRarity::Legendary => assert_eq!(t.price, 10000),
             }
         }
+    }
+
+    // ── Rarity system (Issue #283) ────────────────────────────────────────
+
+    #[test]
+    fn floor_price_matches_the_catalogue_price() {
+        let env = Env::default();
+        for template in get_skin_templates(&env).iter() {
+            assert_eq!(
+                rarity_floor_price(&template.rarity),
+                template.price,
+                "catalogue price and marketplace floor must not drift apart"
+            );
+        }
+    }
+
+    #[test]
+    fn floor_prices_increase_with_rarity() {
+        assert!(
+            rarity_floor_price(&SkinRarity::Common) < rarity_floor_price(&SkinRarity::Rare)
+        );
+        assert!(rarity_floor_price(&SkinRarity::Rare) < rarity_floor_price(&SkinRarity::Epic));
+        assert!(
+            rarity_floor_price(&SkinRarity::Epic) < rarity_floor_price(&SkinRarity::Legendary)
+        );
+    }
+
+    #[test]
+    fn drop_weights_sum_to_the_denominator() {
+        let total = rarity_drop_weight_bps(&SkinRarity::Common)
+            + rarity_drop_weight_bps(&SkinRarity::Rare)
+            + rarity_drop_weight_bps(&SkinRarity::Epic)
+            + rarity_drop_weight_bps(&SkinRarity::Legendary);
+        assert_eq!(total, RARITY_WEIGHT_DENOMINATOR);
+    }
+
+    #[test]
+    fn drop_weights_decrease_with_rarity() {
+        assert!(
+            rarity_drop_weight_bps(&SkinRarity::Common)
+                > rarity_drop_weight_bps(&SkinRarity::Rare)
+        );
+        assert!(
+            rarity_drop_weight_bps(&SkinRarity::Rare) > rarity_drop_weight_bps(&SkinRarity::Epic)
+        );
+        assert!(
+            rarity_drop_weight_bps(&SkinRarity::Epic)
+                > rarity_drop_weight_bps(&SkinRarity::Legendary)
+        );
+    }
+
+    #[test]
+    fn roll_rarity_respects_the_weight_boundaries() {
+        assert_eq!(roll_rarity(0), SkinRarity::Common);
+        assert_eq!(roll_rarity(5_999), SkinRarity::Common);
+        assert_eq!(roll_rarity(6_000), SkinRarity::Rare);
+        assert_eq!(roll_rarity(8_999), SkinRarity::Rare);
+        assert_eq!(roll_rarity(9_000), SkinRarity::Epic);
+        assert_eq!(roll_rarity(9_899), SkinRarity::Epic);
+        assert_eq!(roll_rarity(9_900), SkinRarity::Legendary);
+        assert_eq!(roll_rarity(9_999), SkinRarity::Legendary);
+    }
+
+    #[test]
+    fn roll_rarity_is_deterministic_and_wraps() {
+        assert_eq!(roll_rarity(12_345), roll_rarity(12_345));
+        // Seeds are reduced modulo the denominator.
+        assert_eq!(roll_rarity(10_000), roll_rarity(0));
+        assert_eq!(roll_rarity(u64::MAX), roll_rarity(u64::MAX % 10_000));
+    }
+
+    #[test]
+    fn roll_rarity_produces_the_expected_distribution() {
+        let mut counts = [0u32; 4];
+        for seed in 0..RARITY_WEIGHT_DENOMINATOR as u64 {
+            match roll_rarity(seed) {
+                SkinRarity::Common => counts[0] += 1,
+                SkinRarity::Rare => counts[1] += 1,
+                SkinRarity::Epic => counts[2] += 1,
+                SkinRarity::Legendary => counts[3] += 1,
+            }
+        }
+        // Sweeping every residue reproduces the weights exactly.
+        assert_eq!(counts[0], rarity_drop_weight_bps(&SkinRarity::Common));
+        assert_eq!(counts[1], rarity_drop_weight_bps(&SkinRarity::Rare));
+        assert_eq!(counts[2], rarity_drop_weight_bps(&SkinRarity::Epic));
+        assert_eq!(counts[3], rarity_drop_weight_bps(&SkinRarity::Legendary));
+    }
+
+    #[test]
+    fn effect_layers_increase_with_rarity() {
+        assert_eq!(rarity_effect_layers(&SkinRarity::Common), 0);
+        assert_eq!(rarity_effect_layers(&SkinRarity::Rare), 1);
+        assert_eq!(rarity_effect_layers(&SkinRarity::Epic), 2);
+        assert_eq!(rarity_effect_layers(&SkinRarity::Legendary), 3);
+    }
+
+    #[test]
+    fn rarity_stats_account_for_every_template() {
+        let env = Env::default();
+        let stats = get_rarity_stats(&env);
+        assert_eq!(
+            stats.common + stats.rare + stats.epic + stats.legendary,
+            stats.total
+        );
+        assert!(stats.legendary > 0 && stats.legendary < stats.common);
+    }
+
+    // ── Catalogue lookup ──────────────────────────────────────────────────
+
+    #[test]
+    fn templates_can_be_looked_up_by_name() {
+        let env = Env::default();
+        let found = get_template(&env, symbol_short!("void")).unwrap();
+        assert_eq!(found.rarity, SkinRarity::Legendary);
+        assert!(get_template(&env, symbol_short!("nope")).is_none());
+    }
+
+    #[test]
+    fn templates_can_be_filtered_by_rarity() {
+        let env = Env::default();
+        let legendary = get_templates_by_rarity(&env, SkinRarity::Legendary);
+        assert_eq!(legendary.len(), get_rarity_stats(&env).legendary);
+        for template in legendary.iter() {
+            assert_eq!(template.rarity, SkinRarity::Legendary);
+        }
+    }
+
+    // ── Preview (Issue #283) ──────────────────────────────────────────────
+
+    #[test]
+    fn preview_exposes_gradient_accent_and_pricing() {
+        let env = Env::default();
+        let preview = preview_template(&env, symbol_short!("flame")).unwrap();
+
+        assert_eq!(preview.rarity, SkinRarity::Rare);
+        assert_eq!(preview.gradient.len(), PREVIEW_GRADIENT_STOPS);
+        assert_eq!(preview.floor_price, rarity_floor_price(&SkinRarity::Rare));
+        assert_eq!(
+            preview.drop_weight_bps,
+            rarity_drop_weight_bps(&SkinRarity::Rare)
+        );
+        assert_eq!(preview.effect_layers, 1);
+        assert_eq!(preview.thumbnail_seed.len(), 8);
+    }
+
+    #[test]
+    fn preview_gradient_runs_from_primary_to_secondary() {
+        let env = Env::default();
+        let preview = build_preview(
+            &env,
+            symbol_short!("test"),
+            SkinRarity::Epic,
+            0x000000,
+            0xFFFFFF,
+        );
+
+        assert_eq!(preview.gradient.get(0).unwrap(), 0x000000);
+        assert_eq!(
+            preview.gradient.get(PREVIEW_GRADIENT_STOPS - 1).unwrap(),
+            0xFFFFFF
+        );
+        // Midpoint of black → white is mid grey on every channel.
+        assert_eq!(preview.gradient.get(2).unwrap(), 0x7F7F7F);
+        assert_eq!(preview.color_accent, 0x7F7F7F);
+    }
+
+    #[test]
+    fn preview_handles_a_descending_gradient() {
+        let env = Env::default();
+        let preview = build_preview(
+            &env,
+            symbol_short!("test"),
+            SkinRarity::Common,
+            0xFFFFFF,
+            0x000000,
+        );
+
+        assert_eq!(preview.gradient.get(0).unwrap(), 0xFFFFFF);
+        assert_eq!(preview.gradient.get(2).unwrap(), 0x808080);
+        assert_eq!(
+            preview.gradient.get(PREVIEW_GRADIENT_STOPS - 1).unwrap(),
+            0x000000
+        );
+    }
+
+    #[test]
+    fn preview_is_deterministic_but_distinguishes_cosmetics() {
+        let env = Env::default();
+        let a = preview_template(&env, symbol_short!("void")).unwrap();
+        let b = preview_template(&env, symbol_short!("void")).unwrap();
+        let c = preview_template(&env, symbol_short!("stellar")).unwrap();
+
+        assert_eq!(a, b, "previews are pure functions of the template");
+        assert_ne!(a.thumbnail_seed, c.thumbnail_seed);
+    }
+
+    #[test]
+    fn preview_of_an_unknown_template_is_none() {
+        let env = Env::default();
+        assert!(preview_template(&env, symbol_short!("ghost")).is_none());
+    }
+
+    #[test]
+    fn minted_skin_previews_match_their_template() {
+        let env = Env::default();
+        let template = get_template(&env, symbol_short!("plasma")).unwrap();
+
+        let skin = ShipSkin {
+            skin_id: 1,
+            owner: soroban_sdk::Address::from_str(
+                &env,
+                "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+            ),
+            name: template.name.clone(),
+            rarity: template.rarity.clone(),
+            color_primary: template.color_primary,
+            color_secondary: template.color_secondary,
+            metadata: Bytes::new(&env),
+            tradeable: true,
+        };
+
+        assert_eq!(
+            preview_skin(&env, &skin),
+            preview_template(&env, symbol_short!("plasma")).unwrap()
+        );
     }
 }

--- a/src/token_burning.rs
+++ b/src/token_burning.rs
@@ -1,0 +1,1118 @@
+//! Asset burning for deflationary mechanics — Issue #281
+//!
+//! Every resource sink in the game routes through this module so that supply
+//! removal is accounted for in one place. Three burn mechanisms are provided:
+//!
+//!   1. **Voluntary** — [`burn`], a holder destroys their own resources.
+//!   2. **Sink** — [`burn_for_sink`], a subsystem (crafting, upgrades,
+//!      recycling) destroys resources it has already authorized as the cost of
+//!      an action.
+//!   3. **Fee** — [`apply_deflationary_fee`], a configurable slice of a gross
+//!      amount is burned and the net returned to the caller, making ordinary
+//!      throughput deflationary without a separate player action.
+//!
+//! Burns debit the holder *and* the circulating supply via
+//! [`crate::resource_minter`], which keeps the monotonic `TotalMinted` counter
+//! intact. The deflation rate is therefore `burned / ever_minted` and is exact
+//! rather than estimated — see [`deflation_rate_bps`].
+
+use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env};
+
+use crate::resource_minter::{self, MinterError, ResourceType};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/// Basis-point denominator.
+pub const BPS_DENOMINATOR: u64 = 10_000;
+
+/// Hard ceiling on the configurable burn fee (10 %). Guards against an admin
+/// key setting a confiscatory rate.
+pub const MAX_BURN_FEE_BPS: u32 = 1_000;
+
+/// Burn fee applied by [`apply_deflationary_fee`] until an admin overrides it
+/// (2 %).
+pub const DEFAULT_BURN_FEE_BPS: u32 = 200;
+
+// ─── Storage Keys ─────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+#[contracttype]
+pub enum BurnKey {
+    /// Cumulative burned per resource type.
+    TotalBurned(ResourceType),
+    /// Cumulative burned by a player, across all resource types.
+    PlayerBurned(Address),
+    /// Cumulative burned by a player for one resource type.
+    PlayerBurnedType(Address, ResourceType),
+    /// Number of burn events for a player.
+    PlayerBurnCount(Address),
+    /// Global burn-event counter, also the next burn record ID.
+    BurnCount,
+    /// Individual burn receipt keyed by burn ID.
+    Record(u64),
+    /// Number of distinct addresses that have burned at least once.
+    UniqueBurners,
+    /// Timestamp of the most recent burn.
+    LastBurnAt,
+    /// Configurable fee rate in basis points.
+    FeeBps,
+    /// Admin authorized to change the fee rate.
+    FeeAdmin,
+}
+
+// ─── Data Types ───────────────────────────────────────────────────────────────
+
+/// Why a burn happened. Recorded on every receipt so the economy dashboard can
+/// attribute deflation to the mechanic that caused it.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BurnReason {
+    /// Holder chose to destroy their own resources.
+    Voluntary,
+    /// Consumed as the cost of crafting.
+    Crafting,
+    /// Consumed as the cost of a ship upgrade.
+    Upgrade,
+    /// Slice of a transfer or trade taken as a deflationary fee.
+    TransactionFee,
+    /// Slice of a marketplace sale.
+    MarketplaceFee,
+    /// Removed by governance action (e.g. treasury buy-back).
+    Governance,
+}
+
+/// Immutable receipt for a single burn.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BurnRecord {
+    pub burn_id: u64,
+    pub burner: Address,
+    pub resource_type: ResourceType,
+    pub amount: u64,
+    pub reason: BurnReason,
+    pub burned_at: u64,
+    /// Circulating supply of `resource_type` immediately after this burn.
+    pub supply_after: u64,
+}
+
+/// Global burn statistics for one resource type.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BurnStats {
+    pub resource_type: ResourceType,
+    /// Cumulative amount burned.
+    pub total_burned: u64,
+    /// Cumulative amount ever minted (the deflation denominator).
+    pub total_minted: u64,
+    /// Current circulating supply.
+    pub circulating_supply: u64,
+    /// `total_burned / total_minted` in basis points.
+    pub deflation_rate_bps: u32,
+    /// Global number of burn events (all resource types).
+    pub burn_events: u64,
+    /// Distinct addresses that have burned at least once.
+    pub unique_burners: u64,
+    pub last_burn_at: u64,
+}
+
+/// Per-player burn contribution.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlayerBurnStats {
+    pub player: Address,
+    /// Total burned across all resource types.
+    pub total_burned: u64,
+    /// Number of burn events attributed to this player.
+    pub burn_count: u64,
+    /// Share of all burned supply contributed by this player, in basis points.
+    pub share_bps: u32,
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum BurningError {
+    /// Burn amount must be greater than zero.
+    InvalidAmount = 1,
+    /// Holder does not have enough of the resource to burn.
+    InsufficientBalance = 2,
+    /// Burn accounting overflowed.
+    ArithmeticOverflow = 3,
+    /// Requested fee rate exceeds [`MAX_BURN_FEE_BPS`].
+    FeeRateTooHigh = 4,
+    /// Caller is not the configured fee admin.
+    Unauthorized = 5,
+    /// The fee admin has already been set and cannot be re-initialized.
+    AlreadyInitialized = 6,
+}
+
+impl From<MinterError> for BurningError {
+    fn from(e: MinterError) -> Self {
+        match e {
+            MinterError::InsufficientBalance => BurningError::InsufficientBalance,
+            MinterError::InvalidAmount => BurningError::InvalidAmount,
+            _ => BurningError::ArithmeticOverflow,
+        }
+    }
+}
+
+// ─── Fee configuration ────────────────────────────────────────────────────────
+
+/// Set the admin permitted to change the burn fee rate. One-shot.
+pub fn initialize_burn_admin(env: &Env, admin: Address) -> Result<(), BurningError> {
+    admin.require_auth();
+
+    if env.storage().instance().has(&BurnKey::FeeAdmin) {
+        return Err(BurningError::AlreadyInitialized);
+    }
+    env.storage().instance().set(&BurnKey::FeeAdmin, &admin);
+
+    env.events().publish(
+        (symbol_short!("burn"), symbol_short!("admin")),
+        admin.clone(),
+    );
+
+    Ok(())
+}
+
+/// The currently configured deflationary fee rate, in basis points.
+pub fn get_burn_fee_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&BurnKey::FeeBps)
+        .unwrap_or(DEFAULT_BURN_FEE_BPS)
+}
+
+/// Update the deflationary fee rate (admin only, capped at
+/// [`MAX_BURN_FEE_BPS`]).
+pub fn set_burn_fee_bps(env: &Env, caller: Address, bps: u32) -> Result<(), BurningError> {
+    caller.require_auth();
+
+    if bps > MAX_BURN_FEE_BPS {
+        return Err(BurningError::FeeRateTooHigh);
+    }
+
+    // Before initialization the first caller to set a rate is not privileged;
+    // afterwards only the admin may change it.
+    if let Some(admin) = env
+        .storage()
+        .instance()
+        .get::<BurnKey, Address>(&BurnKey::FeeAdmin)
+    {
+        if admin != caller {
+            return Err(BurningError::Unauthorized);
+        }
+    } else {
+        return Err(BurningError::Unauthorized);
+    }
+
+    let previous = get_burn_fee_bps(env);
+    env.storage().instance().set(&BurnKey::FeeBps, &bps);
+
+    env.events().publish(
+        (symbol_short!("burn"), symbol_short!("feerate")),
+        (caller, previous, bps),
+    );
+
+    Ok(())
+}
+
+// ─── Burn mechanisms ──────────────────────────────────────────────────────────
+
+/// Record a burn against every counter and emit the burn event.
+///
+/// Assumes the holder's balance has already been debited by the caller.
+fn record_burn(
+    env: &Env,
+    burner: &Address,
+    resource_type: &ResourceType,
+    amount: u64,
+    reason: BurnReason,
+    supply_after: u64,
+) -> Result<BurnRecord, BurningError> {
+    // ── Per-type total ────────────────────────────────────────────────────
+    let total_key = BurnKey::TotalBurned(resource_type.clone());
+    let total: u64 = env.storage().persistent().get(&total_key).unwrap_or(0);
+    let new_total = total
+        .checked_add(amount)
+        .ok_or(BurningError::ArithmeticOverflow)?;
+    env.storage().persistent().set(&total_key, &new_total);
+
+    // ── Per-player totals ─────────────────────────────────────────────────
+    let player_key = BurnKey::PlayerBurned(burner.clone());
+    let player_total: u64 = env.storage().persistent().get(&player_key).unwrap_or(0);
+    // Presence of the burn counter — not a non-zero total — is what makes an
+    // address a known burner, so a zero-amount history can never double-count.
+    let is_first_burn = !env
+        .storage()
+        .persistent()
+        .has(&BurnKey::PlayerBurnCount(burner.clone()));
+    let new_player_total = player_total
+        .checked_add(amount)
+        .ok_or(BurningError::ArithmeticOverflow)?;
+    env.storage()
+        .persistent()
+        .set(&player_key, &new_player_total);
+
+    let player_type_key = BurnKey::PlayerBurnedType(burner.clone(), resource_type.clone());
+    let player_type_total: u64 = env
+        .storage()
+        .persistent()
+        .get(&player_type_key)
+        .unwrap_or(0);
+    env.storage().persistent().set(
+        &player_type_key,
+        &player_type_total
+            .checked_add(amount)
+            .ok_or(BurningError::ArithmeticOverflow)?,
+    );
+
+    let count_key = BurnKey::PlayerBurnCount(burner.clone());
+    let player_count: u64 = env.storage().persistent().get(&count_key).unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&count_key, &player_count.saturating_add(1));
+
+    if is_first_burn {
+        let burners: u64 = env
+            .storage()
+            .persistent()
+            .get(&BurnKey::UniqueBurners)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&BurnKey::UniqueBurners, &burners.saturating_add(1));
+    }
+
+    // ── Receipt ───────────────────────────────────────────────────────────
+    let burn_id: u64 = env
+        .storage()
+        .persistent()
+        .get::<BurnKey, u64>(&BurnKey::BurnCount)
+        .unwrap_or(0)
+        .saturating_add(1);
+    env.storage()
+        .persistent()
+        .set(&BurnKey::BurnCount, &burn_id);
+
+    let burned_at = env.ledger().timestamp();
+    let record = BurnRecord {
+        burn_id,
+        burner: burner.clone(),
+        resource_type: resource_type.clone(),
+        amount,
+        reason,
+        burned_at,
+        supply_after,
+    };
+    env.storage()
+        .persistent()
+        .set(&BurnKey::Record(burn_id), &record);
+    env.storage()
+        .persistent()
+        .set(&BurnKey::LastBurnAt, &burned_at);
+
+    env.events().publish(
+        (symbol_short!("burn"), symbol_short!("burned")),
+        (
+            burner.clone(),
+            resource_type.clone(),
+            amount,
+            reason,
+            supply_after,
+        ),
+    );
+
+    // A burn that empties the circulating supply is worth surfacing on its own
+    // topic — it means every minted unit of the resource is now destroyed.
+    if supply_after == 0 {
+        env.events().publish(
+            (symbol_short!("burn"), symbol_short!("supply0")),
+            (resource_type.clone(), new_total),
+        );
+    }
+
+    Ok(record)
+}
+
+/// Destroy `amount` of the caller's own resources.
+///
+/// Requires the burner's authorization. Debits the balance, reduces the
+/// circulating supply and emits `burn/burned`.
+pub fn burn(
+    env: &Env,
+    burner: Address,
+    resource_type: ResourceType,
+    amount: u64,
+    reason: BurnReason,
+) -> Result<BurnRecord, BurningError> {
+    burner.require_auth();
+    burn_for_sink(env, &burner, &resource_type, amount, reason)
+}
+
+/// Destroy `amount` of `holder`'s resources without requiring their auth.
+///
+/// For subsystem sinks (crafting, upgrades, fees) that have already established
+/// the holder's consent to spend. Callers that have *not* must use [`burn`].
+pub fn burn_for_sink(
+    env: &Env,
+    holder: &Address,
+    resource_type: &ResourceType,
+    amount: u64,
+    reason: BurnReason,
+) -> Result<BurnRecord, BurningError> {
+    if amount == 0 {
+        return Err(BurningError::InvalidAmount);
+    }
+
+    // Debit the holder first so an insufficient balance aborts before any
+    // supply or statistics state is touched.
+    resource_minter::debit_balance(env, holder, resource_type, amount)?;
+    let supply_after = resource_minter::reduce_supply(env, resource_type, amount)?;
+
+    record_burn(env, holder, resource_type, amount, reason, supply_after)
+}
+
+/// Burn the configured fee slice of `gross` and return the net amount.
+///
+/// This is the mechanism that makes ordinary throughput deflationary: callers
+/// that move resources around route the gross amount through here and forward
+/// the returned net. A `gross` too small to produce a non-zero fee is passed
+/// through untouched rather than rounding the fee up.
+pub fn apply_deflationary_fee(
+    env: &Env,
+    holder: &Address,
+    resource_type: &ResourceType,
+    gross: u64,
+    reason: BurnReason,
+) -> Result<u64, BurningError> {
+    if gross == 0 {
+        return Err(BurningError::InvalidAmount);
+    }
+
+    let fee_bps = get_burn_fee_bps(env) as u64;
+    let fee = gross
+        .checked_mul(fee_bps)
+        .ok_or(BurningError::ArithmeticOverflow)?
+        / BPS_DENOMINATOR;
+
+    if fee == 0 {
+        return Ok(gross);
+    }
+
+    burn_for_sink(env, holder, resource_type, fee, reason)?;
+
+    // `fee <= gross` because fee_bps <= MAX_BURN_FEE_BPS < BPS_DENOMINATOR.
+    Ok(gross - fee)
+}
+
+/// Transfer resources from `from` to `to`, burning the deflationary fee.
+///
+/// The primary mechanism by which ordinary throughput reduces supply: the
+/// sender is charged `amount`, the fee slice is destroyed, and the recipient
+/// receives the net. Returns the net amount credited to `to`.
+pub fn transfer_with_burn(
+    env: &Env,
+    from: Address,
+    to: Address,
+    resource_type: ResourceType,
+    amount: u64,
+) -> Result<u64, BurningError> {
+    from.require_auth();
+
+    if amount == 0 {
+        return Err(BurningError::InvalidAmount);
+    }
+    // Check up front so the sender is never charged the fee on a transfer that
+    // cannot complete.
+    if resource_minter::balance_of(env, &from, &resource_type) < amount {
+        return Err(BurningError::InsufficientBalance);
+    }
+
+    let net = apply_deflationary_fee(
+        env,
+        &from,
+        &resource_type,
+        amount,
+        BurnReason::TransactionFee,
+    )?;
+
+    resource_minter::move_balance(env, &from, &to, &resource_type, net)?;
+
+    env.events().publish(
+        (symbol_short!("burn"), symbol_short!("xferburn")),
+        (from, to, resource_type, amount, net),
+    );
+
+    Ok(net)
+}
+
+// ─── Statistics ───────────────────────────────────────────────────────────────
+
+/// Cumulative amount burned for one resource type.
+pub fn total_burned(env: &Env, resource_type: &ResourceType) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&BurnKey::TotalBurned(resource_type.clone()))
+        .unwrap_or(0)
+}
+
+/// Fraction of all ever-minted supply that has been burned, in basis points.
+///
+/// Returns 0 when nothing has been minted yet.
+pub fn deflation_rate_bps(env: &Env, resource_type: &ResourceType) -> u32 {
+    let minted = resource_minter::total_minted(env, resource_type);
+    if minted == 0 {
+        return 0;
+    }
+    let burned = total_burned(env, resource_type);
+
+    // burned <= minted always, so the quotient fits comfortably in u32.
+    let rate = (burned as u128 * BPS_DENOMINATOR as u128) / minted as u128;
+    rate as u32
+}
+
+/// Full burn statistics for one resource type.
+pub fn get_burn_stats(env: &Env, resource_type: ResourceType) -> BurnStats {
+    BurnStats {
+        total_burned: total_burned(env, &resource_type),
+        total_minted: resource_minter::total_minted(env, &resource_type),
+        circulating_supply: resource_minter::circulating_supply(env, &resource_type),
+        deflation_rate_bps: deflation_rate_bps(env, &resource_type),
+        burn_events: env
+            .storage()
+            .persistent()
+            .get(&BurnKey::BurnCount)
+            .unwrap_or(0),
+        unique_burners: env
+            .storage()
+            .persistent()
+            .get(&BurnKey::UniqueBurners)
+            .unwrap_or(0),
+        last_burn_at: env
+            .storage()
+            .persistent()
+            .get(&BurnKey::LastBurnAt)
+            .unwrap_or(0),
+        resource_type,
+    }
+}
+
+/// A single player's burn contribution across all resource types.
+pub fn get_player_burn_stats(env: &Env, player: Address) -> PlayerBurnStats {
+    let total_burned: u64 = env
+        .storage()
+        .persistent()
+        .get(&BurnKey::PlayerBurned(player.clone()))
+        .unwrap_or(0);
+    let burn_count: u64 = env
+        .storage()
+        .persistent()
+        .get(&BurnKey::PlayerBurnCount(player.clone()))
+        .unwrap_or(0);
+
+    // Share is measured against the sum of every resource type's burn total.
+    let global_burned = total_burned_all(env);
+    let share_bps = if global_burned == 0 {
+        0
+    } else {
+        ((total_burned as u128 * BPS_DENOMINATOR as u128) / global_burned as u128) as u32
+    };
+
+    PlayerBurnStats {
+        player,
+        total_burned,
+        burn_count,
+        share_bps,
+    }
+}
+
+/// Sum of burned amounts across every resource type.
+pub fn total_burned_all(env: &Env) -> u64 {
+    total_burned(env, &ResourceType::StellarDust)
+        .saturating_add(total_burned(env, &ResourceType::DarkMatter))
+        .saturating_add(total_burned(env, &ResourceType::ExoticMatter))
+}
+
+/// Amount a player has burned of one specific resource type.
+pub fn player_burned_of(env: &Env, player: &Address, resource_type: &ResourceType) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&BurnKey::PlayerBurnedType(
+            player.clone(),
+            resource_type.clone(),
+        ))
+        .unwrap_or(0)
+}
+
+/// Retrieve a burn receipt by ID.
+pub fn get_burn_record(env: &Env, burn_id: u64) -> Option<BurnRecord> {
+    env.storage().persistent().get(&BurnKey::Record(burn_id))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{contract, contractimpl};
+
+    #[contract]
+    struct Stub;
+    #[contractimpl]
+    impl Stub {}
+
+    /// Burning touches the balance, supply and statistics ledgers, so tests run
+    /// inside a contract invocation. Each `run` is a fresh frame — necessary
+    /// because `require_auth` may only be satisfied once per frame, so two
+    /// authorized burns cannot share one.
+    struct Harness {
+        env: Env,
+        contract: Address,
+        holder: Address,
+        rt: ResourceType,
+    }
+
+    fn setup(seed_amount: u64) -> Harness {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract = env.register(Stub, ());
+        let holder = Address::generate(&env);
+        let rt = ResourceType::StellarDust;
+
+        let h = Harness {
+            env,
+            contract,
+            holder,
+            rt,
+        };
+        if seed_amount > 0 {
+            let holder = h.holder.clone();
+            let rt = h.rt.clone();
+            h.run(|| {
+                resource_minter::credit_balance(&h.env, &holder, &rt, seed_amount).unwrap();
+            });
+        }
+        h
+    }
+
+    impl Harness {
+        fn run<T>(&self, f: impl FnOnce() -> T) -> T {
+            self.env.as_contract(&self.contract, f)
+        }
+    }
+
+    // ── Burn mechanisms ───────────────────────────────────────────────────
+
+    #[test]
+    fn voluntary_burn_reduces_balance_and_supply() {
+        let h = setup(1_000);
+
+        let record = h.run(|| {
+            burn(
+                &h.env,
+                h.holder.clone(),
+                h.rt.clone(),
+                250,
+                BurnReason::Voluntary,
+            )
+            .unwrap()
+        });
+
+        assert_eq!(record.amount, 250);
+        assert_eq!(record.reason, BurnReason::Voluntary);
+        assert_eq!(record.supply_after, 750);
+        h.run(|| {
+            assert_eq!(resource_minter::balance_of(&h.env, &h.holder, &h.rt), 750);
+            assert_eq!(resource_minter::circulating_supply(&h.env, &h.rt), 750);
+        });
+    }
+
+    #[test]
+    fn burning_never_reduces_the_historical_mint_total() {
+        let h = setup(1_000);
+        h.run(|| {
+            burn(
+                &h.env,
+                h.holder.clone(),
+                h.rt.clone(),
+                400,
+                BurnReason::Voluntary,
+            )
+            .unwrap()
+        });
+
+        h.run(|| {
+            assert_eq!(resource_minter::total_minted(&h.env, &h.rt), 1_000);
+            assert_eq!(resource_minter::circulating_supply(&h.env, &h.rt), 600);
+        });
+    }
+
+    #[test]
+    fn burn_beyond_balance_is_rejected_and_changes_nothing() {
+        let h = setup(100);
+
+        h.run(|| {
+            assert_eq!(
+                burn(
+                    &h.env,
+                    h.holder.clone(),
+                    h.rt.clone(),
+                    101,
+                    BurnReason::Voluntary
+                ),
+                Err(BurningError::InsufficientBalance)
+            );
+        });
+
+        h.run(|| {
+            assert_eq!(resource_minter::balance_of(&h.env, &h.holder, &h.rt), 100);
+            assert_eq!(resource_minter::circulating_supply(&h.env, &h.rt), 100);
+            assert_eq!(total_burned(&h.env, &h.rt), 0);
+        });
+    }
+
+    #[test]
+    fn zero_burn_is_rejected() {
+        let h = setup(100);
+        h.run(|| {
+            assert_eq!(
+                burn(
+                    &h.env,
+                    h.holder.clone(),
+                    h.rt.clone(),
+                    0,
+                    BurnReason::Voluntary
+                ),
+                Err(BurningError::InvalidAmount)
+            );
+        });
+    }
+
+    #[test]
+    fn sink_burn_attributes_the_reason() {
+        let h = setup(500);
+
+        let record =
+            h.run(|| burn_for_sink(&h.env, &h.holder, &h.rt, 120, BurnReason::Crafting).unwrap());
+        assert_eq!(record.reason, BurnReason::Crafting);
+        assert_eq!(record.burner, h.holder);
+    }
+
+    // ── Deflationary fee ──────────────────────────────────────────────────
+
+    #[test]
+    fn deflationary_fee_burns_a_slice_and_returns_the_net() {
+        let h = setup(10_000);
+
+        // Default 2 % of 1_000 = 20.
+        let net = h.run(|| {
+            apply_deflationary_fee(&h.env, &h.holder, &h.rt, 1_000, BurnReason::TransactionFee)
+                .unwrap()
+        });
+
+        assert_eq!(net, 980);
+        h.run(|| {
+            assert_eq!(total_burned(&h.env, &h.rt), 20);
+            assert_eq!(resource_minter::balance_of(&h.env, &h.holder, &h.rt), 9_980);
+        });
+    }
+
+    #[test]
+    fn deflationary_fee_passes_dust_amounts_through_untouched() {
+        let h = setup(1_000);
+
+        // 2 % of 10 rounds down to 0 — no burn rather than a rounded-up fee.
+        let net = h.run(|| {
+            apply_deflationary_fee(&h.env, &h.holder, &h.rt, 10, BurnReason::TransactionFee)
+                .unwrap()
+        });
+
+        assert_eq!(net, 10);
+        h.run(|| {
+            assert_eq!(total_burned(&h.env, &h.rt), 0);
+            assert_eq!(resource_minter::balance_of(&h.env, &h.holder, &h.rt), 1_000);
+        });
+    }
+
+    #[test]
+    fn deflationary_fee_rejects_zero_gross() {
+        let h = setup(1_000);
+        h.run(|| {
+            assert_eq!(
+                apply_deflationary_fee(&h.env, &h.holder, &h.rt, 0, BurnReason::TransactionFee),
+                Err(BurningError::InvalidAmount)
+            );
+        });
+    }
+
+    // ── Transfer with burn ────────────────────────────────────────────────
+
+    #[test]
+    fn transfer_with_burn_charges_the_sender_and_shrinks_supply() {
+        let h = setup(10_000);
+        let recipient = Address::generate(&h.env);
+
+        // 2 % of 1_000 = 20 burned; the recipient gets 980.
+        let net = h.run(|| {
+            transfer_with_burn(
+                &h.env,
+                h.holder.clone(),
+                recipient.clone(),
+                h.rt.clone(),
+                1_000,
+            )
+            .unwrap()
+        });
+
+        assert_eq!(net, 980);
+        h.run(|| {
+            assert_eq!(resource_minter::balance_of(&h.env, &h.holder, &h.rt), 9_000);
+            assert_eq!(resource_minter::balance_of(&h.env, &recipient, &h.rt), 980);
+            assert_eq!(resource_minter::circulating_supply(&h.env, &h.rt), 9_980);
+            assert_eq!(total_burned(&h.env, &h.rt), 20);
+            assert_eq!(
+                resource_minter::total_minted(&h.env, &h.rt),
+                10_000,
+                "a transfer must not inflate the historical mint total"
+            );
+        });
+    }
+
+    #[test]
+    fn transfer_with_burn_rejects_an_underfunded_sender_without_charging_a_fee() {
+        let h = setup(100);
+        let recipient = Address::generate(&h.env);
+
+        h.run(|| {
+            assert_eq!(
+                transfer_with_burn(
+                    &h.env,
+                    h.holder.clone(),
+                    recipient.clone(),
+                    h.rt.clone(),
+                    101
+                ),
+                Err(BurningError::InsufficientBalance)
+            );
+        });
+
+        h.run(|| {
+            assert_eq!(resource_minter::balance_of(&h.env, &h.holder, &h.rt), 100);
+            assert_eq!(total_burned(&h.env, &h.rt), 0);
+        });
+    }
+
+    #[test]
+    fn transfer_with_burn_rejects_zero() {
+        let h = setup(100);
+        let recipient = Address::generate(&h.env);
+        h.run(|| {
+            assert_eq!(
+                transfer_with_burn(&h.env, h.holder.clone(), recipient, h.rt.clone(), 0),
+                Err(BurningError::InvalidAmount)
+            );
+        });
+    }
+
+    // ── Fee configuration ─────────────────────────────────────────────────
+
+    #[test]
+    fn fee_rate_is_admin_gated_and_capped() {
+        let h = setup(0);
+        let admin = Address::generate(&h.env);
+        let stranger = h.holder.clone();
+
+        h.run(|| initialize_burn_admin(&h.env, admin.clone()).unwrap());
+        h.run(|| assert_eq!(get_burn_fee_bps(&h.env), DEFAULT_BURN_FEE_BPS));
+
+        h.run(|| set_burn_fee_bps(&h.env, admin.clone(), 500).unwrap());
+        h.run(|| assert_eq!(get_burn_fee_bps(&h.env), 500));
+
+        h.run(|| {
+            assert_eq!(
+                set_burn_fee_bps(&h.env, admin.clone(), MAX_BURN_FEE_BPS + 1),
+                Err(BurningError::FeeRateTooHigh)
+            );
+        });
+        h.run(|| {
+            assert_eq!(
+                set_burn_fee_bps(&h.env, stranger.clone(), 100),
+                Err(BurningError::Unauthorized)
+            );
+        });
+        h.run(|| {
+            assert_eq!(
+                get_burn_fee_bps(&h.env),
+                500,
+                "rejected writes change nothing"
+            )
+        });
+    }
+
+    #[test]
+    fn burn_admin_cannot_be_reinitialized() {
+        let h = setup(0);
+        let admin = Address::generate(&h.env);
+        let usurper = Address::generate(&h.env);
+
+        h.run(|| initialize_burn_admin(&h.env, admin.clone()).unwrap());
+        h.run(|| {
+            assert_eq!(
+                initialize_burn_admin(&h.env, usurper.clone()),
+                Err(BurningError::AlreadyInitialized)
+            );
+        });
+    }
+
+    #[test]
+    fn fee_rate_cannot_be_set_before_an_admin_exists() {
+        let h = setup(0);
+        h.run(|| {
+            assert_eq!(
+                set_burn_fee_bps(&h.env, h.holder.clone(), 100),
+                Err(BurningError::Unauthorized)
+            );
+        });
+    }
+
+    #[test]
+    fn configured_fee_rate_is_honoured_by_the_fee_path() {
+        let h = setup(10_000);
+        let admin = Address::generate(&h.env);
+        h.run(|| initialize_burn_admin(&h.env, admin.clone()).unwrap());
+        h.run(|| set_burn_fee_bps(&h.env, admin.clone(), MAX_BURN_FEE_BPS).unwrap());
+
+        // 10 % of 1_000 = 100.
+        let net = h.run(|| {
+            apply_deflationary_fee(&h.env, &h.holder, &h.rt, 1_000, BurnReason::MarketplaceFee)
+                .unwrap()
+        });
+        assert_eq!(net, 900);
+        h.run(|| assert_eq!(total_burned(&h.env, &h.rt), 100));
+    }
+
+    // ── Statistics ────────────────────────────────────────────────────────
+
+    #[test]
+    fn deflation_rate_reflects_burned_over_minted() {
+        let h = setup(1_000);
+        h.run(|| assert_eq!(deflation_rate_bps(&h.env, &h.rt), 0));
+
+        h.run(|| {
+            burn(
+                &h.env,
+                h.holder.clone(),
+                h.rt.clone(),
+                250,
+                BurnReason::Voluntary,
+            )
+            .unwrap()
+        });
+
+        // 250 / 1000 = 25 % = 2_500 bps.
+        h.run(|| assert_eq!(deflation_rate_bps(&h.env, &h.rt), 2_500));
+    }
+
+    #[test]
+    fn deflation_rate_is_zero_before_anything_is_minted() {
+        let h = setup(0);
+        h.run(|| assert_eq!(deflation_rate_bps(&h.env, &ResourceType::DarkMatter), 0));
+    }
+
+    #[test]
+    fn burn_stats_aggregate_the_whole_picture() {
+        let h = setup(2_000);
+        h.run(|| {
+            burn(
+                &h.env,
+                h.holder.clone(),
+                h.rt.clone(),
+                300,
+                BurnReason::Voluntary,
+            )
+            .unwrap()
+        });
+        h.run(|| {
+            burn(
+                &h.env,
+                h.holder.clone(),
+                h.rt.clone(),
+                200,
+                BurnReason::Crafting,
+            )
+            .unwrap()
+        });
+
+        h.run(|| {
+            let stats = get_burn_stats(&h.env, h.rt.clone());
+            assert_eq!(stats.resource_type, h.rt);
+            assert_eq!(stats.total_burned, 500);
+            assert_eq!(stats.total_minted, 2_000);
+            assert_eq!(stats.circulating_supply, 1_500);
+            assert_eq!(stats.deflation_rate_bps, 2_500);
+            assert_eq!(stats.burn_events, 2);
+            assert_eq!(stats.unique_burners, 1);
+            assert_eq!(stats.last_burn_at, h.env.ledger().timestamp());
+        });
+    }
+
+    #[test]
+    fn per_player_stats_track_share_of_total_burned() {
+        let h = setup(1_000);
+        let alice = h.holder.clone();
+        let bob = Address::generate(&h.env);
+
+        h.run(|| resource_minter::credit_balance(&h.env, &bob, &h.rt, 1_000).unwrap());
+        h.run(|| {
+            burn(
+                &h.env,
+                alice.clone(),
+                h.rt.clone(),
+                300,
+                BurnReason::Voluntary,
+            )
+            .unwrap()
+        });
+        h.run(|| {
+            burn(
+                &h.env,
+                bob.clone(),
+                h.rt.clone(),
+                100,
+                BurnReason::Voluntary,
+            )
+            .unwrap()
+        });
+
+        h.run(|| {
+            let alice_stats = get_player_burn_stats(&h.env, alice.clone());
+            let bob_stats = get_player_burn_stats(&h.env, bob.clone());
+
+            assert_eq!(alice_stats.total_burned, 300);
+            assert_eq!(alice_stats.burn_count, 1);
+            assert_eq!(alice_stats.share_bps, 7_500);
+            assert_eq!(bob_stats.total_burned, 100);
+            assert_eq!(bob_stats.share_bps, 2_500);
+            assert_eq!(get_burn_stats(&h.env, h.rt.clone()).unique_burners, 2);
+        });
+    }
+
+    #[test]
+    fn per_player_stats_are_zero_for_a_non_burner() {
+        let h = setup(0);
+        let stranger = Address::generate(&h.env);
+
+        h.run(|| {
+            let stats = get_player_burn_stats(&h.env, stranger.clone());
+            assert_eq!(stats.total_burned, 0);
+            assert_eq!(stats.burn_count, 0);
+            assert_eq!(stats.share_bps, 0);
+        });
+    }
+
+    #[test]
+    fn burn_totals_are_tracked_per_resource_type() {
+        let h = setup(0);
+        let holder = h.holder.clone();
+
+        h.run(|| {
+            resource_minter::credit_balance(&h.env, &holder, &ResourceType::StellarDust, 500)
+                .unwrap();
+            resource_minter::credit_balance(&h.env, &holder, &ResourceType::DarkMatter, 500)
+                .unwrap();
+        });
+
+        h.run(|| {
+            burn(
+                &h.env,
+                holder.clone(),
+                ResourceType::StellarDust,
+                100,
+                BurnReason::Voluntary,
+            )
+            .unwrap()
+        });
+        h.run(|| {
+            burn(
+                &h.env,
+                holder.clone(),
+                ResourceType::DarkMatter,
+                50,
+                BurnReason::Upgrade,
+            )
+            .unwrap()
+        });
+
+        h.run(|| {
+            assert_eq!(total_burned(&h.env, &ResourceType::StellarDust), 100);
+            assert_eq!(total_burned(&h.env, &ResourceType::DarkMatter), 50);
+            assert_eq!(total_burned(&h.env, &ResourceType::ExoticMatter), 0);
+            assert_eq!(total_burned_all(&h.env), 150);
+            assert_eq!(
+                player_burned_of(&h.env, &holder, &ResourceType::StellarDust),
+                100
+            );
+        });
+    }
+
+    #[test]
+    fn burn_receipts_are_retrievable_and_sequential() {
+        let h = setup(1_000);
+
+        let first = h.run(|| {
+            burn(
+                &h.env,
+                h.holder.clone(),
+                h.rt.clone(),
+                10,
+                BurnReason::Voluntary,
+            )
+            .unwrap()
+        });
+        let second = h.run(|| {
+            burn(
+                &h.env,
+                h.holder.clone(),
+                h.rt.clone(),
+                20,
+                BurnReason::Governance,
+            )
+            .unwrap()
+        });
+
+        assert_eq!(first.burn_id, 1);
+        assert_eq!(second.burn_id, 2);
+        h.run(|| {
+            assert_eq!(get_burn_record(&h.env, 1), Some(first.clone()));
+            assert_eq!(get_burn_record(&h.env, 2), Some(second.clone()));
+            assert_eq!(get_burn_record(&h.env, 3), None);
+        });
+    }
+
+    #[test]
+    fn burning_the_entire_supply_is_permitted() {
+        let h = setup(750);
+
+        let record = h.run(|| {
+            burn(
+                &h.env,
+                h.holder.clone(),
+                h.rt.clone(),
+                750,
+                BurnReason::Governance,
+            )
+            .unwrap()
+        });
+
+        assert_eq!(record.supply_after, 0);
+        h.run(|| {
+            assert_eq!(resource_minter::balance_of(&h.env, &h.holder, &h.rt), 0);
+            assert_eq!(deflation_rate_bps(&h.env, &h.rt), BPS_DENOMINATOR as u32);
+        });
+    }
+}


### PR DESCRIPTION
Implements four gameplay and economy systems. Each commit is self-contained and builds on its own.

Closes #280
Closes #281
Closes #282
Closes #283

---

### #280 — Daily login rewards · `feat(retention)`
`src/daily_rewards.rs` (new), `src/player_profile.rs`

Two independent axes drive the loop: a fixed **28-day calendar** decides *what* a claim pays (essence, one of the three resource types, energy, or a cosmetic roll), and the player's consecutive-login **streak** decides *how much* (+500 bps/day, capped at 30 000 bps so a long streak can't mint unbounded essence). Weekly slots (7/14/21/28) pay 4× base; the cycle finale pays 10× and is always a cosmetic roll.

Calendar slots advance with **claims**, not wall-clock days — a missed day costs the streak bonus but never desyncs a player from the calendar. `resolve_reward` / `get_reward_calendar` are pure, so a client can render the month ahead and preview the exact next payout without touching state.

`player_profile` gains `credit_essence` (checked, credit-only) and `record_login`, giving the streak one authoritative home on the profile while `daily_rewards` owns the calendar and payouts.

### #281 — Token burning for deflation · `feat(economy)`
`src/token_burning.rs` (new), `src/resource_minter.rs`

Every resource sink routes through one module, via three mechanisms:

| Mechanism | Entry point | Use |
|---|---|---|
| Voluntary | `burn` | Holder destroys their own resources |
| Sink | `burn_for_sink` | Crafting / upgrades / recycling costs |
| Fee | `apply_deflationary_fee`, `transfer_with_burn` | A slice of throughput is destroyed, net forwarded |

Every burn writes an immutable receipt carrying its `BurnReason`, so deflation can be attributed to the mechanic that caused it. `resource_minter` gains a **monotonic** `TotalMinted` counter alongside `TotalSupply` — burning reduces supply but never the historical mint total, which makes `deflation_rate_bps` (burned ÷ ever-minted) exact rather than estimated.

The fee rate is admin-gated and capped at 10 %. Fees too small to produce a non-zero burn pass through untouched rather than rounding up, and `transfer_with_burn` checks the balance before charging so a sender is never billed for a transfer that can't complete.

### #282 — Quest system · `feat(content)`
`src/quest_system.rs` (new), `src/mission_generator.rs`

Guided multi-step content layered on the existing one-shot dailies. A quest is a **node in a chain**: claiming a node unlocks one of several successors, so a chain is a branching narrative rather than a fixed list.

```
node1 ─┬─ choice 1 ─► node2 ─► (end)
       └─ choice 2 ─► node3 ─► (end)
```

Nodes carry an objective, target, narrative tier, title/description and a mixed reward (essence, resources, XP, cosmetic roll). Branching is gated on having **claimed** the node, so a player can't skip a payout by racing ahead, and a chosen branch is immutable — the path walked is recorded in `ChainProgress::path`.

`mission_generator` forwards claimed missions into `on_mission_completed`, advancing every active quest whose objective matches, so normal play drives chains forward. Per-quest errors are swallowed there — a mission claim must never fail because of unrelated quest state — and iteration is bounded by `MAX_ACTIVE_QUESTS`, keeping the call's cost constant.

### #283 — Cosmetic NFT marketplace · `feat(marketplace)`
`src/skins.rs`, `src/nft_marketplace.rs`, `src/ship_customization.rs`

Cosmetics are strictly non-functional (colours and effect layers only, never ship stats), so this is revenue without pay-to-win. Kept separate from the existing ship market rather than generalised over both, because cosmetics carry a perpetual creator royalty, are floor-priced by rarity, and are escrowed while listed — none of which applies to ships.

`skins.rs` adds the **rarity model** (floor prices matching catalogue mint price, drop weights summing to exactly 10 000 bps, deterministic `roll_rarity`) and **preview functionality**: `SkinPreview` returns a derived accent, five-stop gradient, effect-layer count, pricing/odds and a deterministic thumbnail seed, so a storefront can render an unowned cosmetic without touching state.

Marketplace mechanics:
- `list_cosmetic` verifies ownership, enforces the rarity floor, and clears `tradeable` so a cosmetic can't be sold twice or moved out from under an open listing
- `buy_cosmetic` transfers the skin, releases escrow, and settles creator royalty / 2.5 % platform fee / seller proceeds
- `register_creator_royalty` is owner-gated and one-shot, so a later holder can't redirect a creator's royalty stream
- `withdraw_creator_earnings` zeroes the balance before emitting, so a re-entrant call finds nothing left

An unregistered cosmetic pays **no** royalty rather than accruing one to nobody — that share stays with the seller.

---

## Testing

**149 new unit tests, all passing.** Storage-touching tests run inside `Env::as_contract`, matching the existing convention in `src/crafting.rs`; each authorized call gets its own invocation frame, since `require_auth` may only be satisfied once per frame.

| Module | Tests |
|---|---|
| `daily_rewards` | 20 |
| `token_burning` | 23 |
| `quest_system` | 34 |
| `nft_marketplace` (cosmetic) | 29 |
| `skins` | 17 new |
| `resource_minter` (supply primitives) | 10 |
| `player_profile` | 7 |
| `ship_customization` (marketplace hooks) | 5 |

Coverage includes the full happy paths plus rejection paths, arithmetic-overflow behaviour on every balance-modifying operation, escrow/double-sell prevention, royalty redirection attempts, streak-break and calendar-wrap edges, quest expiry, and exhaustive `roll_rarity` distribution over all 10 000 residues.

## Notes on pre-existing state

These were already failing on `main` and are **untouched** by this PR:

- `cargo test --lib` does not compile at all on `main` — 18 errors in `access_control.rs`, `nebula_gen.rs`, `realtime_events.rs`, `integrations/horizon_client.rs`. I verified my tests by temporarily patching those modules out locally; **that patch is not part of this branch**.
- WASM release build fails with 5 pre-existing `no_std` `f64` errors (`powf`/`round`) in `pvp_combat.rs`.
- 4 pre-existing unit tests in `resource_minter` and `ship_customization` fail for the same missing-`as_contract` reason as the rest of the suite.
- `cargo fmt --all -- --check` already fails on `main`. The three new files are `rustfmt`-clean; I did not reformat the pre-existing files, which would have buried the real diff in unrelated churn.

`cargo build` (native) succeeds, and total warning count is **down** from 316 to 314.
