### PR TITLE
docs: add modulelevel documentation across codebase

### DIFF
--- a/docs/MODULE_ARCHITECTURE.md
+++ b/docs/MODULE_ARCHITECTURE.md
@@ -1,0 +1,47 @@
+# Module architecture
+
+Nebula Nomad is organized as a set of bounded gameplay and infrastructure
+modules exposed through the root contract facade in `src/lib.rs`.
+
+## Gameplay domains
+
+- Exploration modules generate nebulae, constellations, missions, and
+  environmental state.
+- Progression modules manage achievements, badges, battle passes, difficulty,
+  player energy, and seasonal content.
+- Social modules own alliances, clans, communication, gifting, and reputation.
+- Economy modules own resources, recipes, crafting, trading, bounties, and DEX
+  integration.
+
+## Infrastructure domains
+
+- Access-control and emergency modules protect privileged operations.
+- Audit, analytics, metrics, and event modules expose observable state changes.
+- Cache, storage, migration, and versioning modules manage lifecycle and
+  upgrade compatibility.
+- Batch and configuration modules bound work and delay sensitive changes.
+
+## Dependency direction
+
+Feature modules may depend on shared types and infrastructure utilities.
+Infrastructure modules must not call high-level gameplay modules. The root
+contract facade coordinates cross-domain operations and remains the only place
+that should expose unrelated domains through one public interface.
+
+## Module documentation standard
+
+Every Rust module starts with `//!` documentation explaining its responsibility.
+Public functions that mutate state should document authorization, storage
+effects, emitted events, errors, and a short usage example where the call
+sequence is not obvious.
+
+```rust
+//! Player energy balances, spending, and regeneration.
+
+/// Spends energy after authenticating the player.
+///
+/// Returns an error when the balance is insufficient.
+pub fn spend_energy(/* ... */) {
+    // ...
+}
+```

--- a/src/achievement_engine.rs
+++ b/src/achievement_engine.rs
@@ -1,3 +1,5 @@
+//! Achievement eligibility evaluation and badge issuance.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, String, Symbol, Vec};
 
 use crate::health_monitor;

--- a/src/achievements.rs
+++ b/src/achievements.rs
@@ -1,3 +1,5 @@
+//! Achievement catalog, progress tracking, and seasonal unlock orchestration.
+//!
 /// # Achievements Module
 ///
 /// Provides the public achievement catalog, on-chain progress tracking,

--- a/src/ai_mission_engine.rs
+++ b/src/ai_mission_engine.rs
@@ -1,3 +1,5 @@
+//! Player-aware procedural mission generation.
+//!
 use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol, Vec};
 
 use crate::player_profile::get_profile_by_owner;

--- a/src/alliance_manager.rs
+++ b/src/alliance_manager.rs
@@ -1,3 +1,5 @@
+//! Alliance membership, treasury, and progression management.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, String, Vec};
 
 use crate::input_validation;

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,3 +1,5 @@
+//! On-chain gameplay metrics aggregation and queries.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Vec};
 
 // ── Error ─────────────────────────────────────────────────────────────────────

--- a/src/anomaly_classifier.rs
+++ b/src/anomaly_classifier.rs
@@ -1,3 +1,5 @@
+//! Classification of suspicious gameplay and telemetry anomalies.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Symbol, Vec};
 
 #[derive(Clone)]

--- a/src/audio_seed_generator.rs
+++ b/src/audio_seed_generator.rs
@@ -1,3 +1,5 @@
+//! Deterministic audio seed generation for game content.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Env, BytesN, Vec};
 
 // Audio generation constants

--- a/src/audit_logger.rs
+++ b/src/audit_logger.rs
@@ -1,3 +1,5 @@
+//! Structured, append-only audit event recording.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, BytesN, Env, Symbol, Vec};
 
 pub const MAX_QUERY_LIMIT: u32 = 1000;

--- a/src/badges.rs
+++ b/src/badges.rs
@@ -1,3 +1,5 @@
+//! Badge definitions, ownership, and award operations.
+//!
 /// # Badges Module
 ///
 /// Handles Badge NFT minting, display metadata, and transfer logic for the

--- a/src/batch_processor.rs
+++ b/src/batch_processor.rs
@@ -1,3 +1,5 @@
+//! Bounded batch execution for contract operations.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Vec};
 
 use crate::rate_limiter;

--- a/src/battle_pass.rs
+++ b/src/battle_pass.rs
@@ -1,3 +1,5 @@
+//! Battle-pass seasons, tiers, and reward claims.
+//!
 use soroban_sdk::{contracttype, contracterror, symbol_short, Address, Env, String, Symbol, Vec};
 use crate::seasons::get_current_season;
 

--- a/src/blueprint_factory.rs
+++ b/src/blueprint_factory.rs
@@ -1,3 +1,5 @@
+//! Blueprint creation and validation for craftable assets.
+//!
 use soroban_sdk::{contracttype, contracterror, symbol_short, Address, Env, Symbol, Vec};
 
 /// Maximum blueprints that can be crafted in a single batch transaction.

--- a/src/bounty_board.rs
+++ b/src/bounty_board.rs
@@ -1,3 +1,5 @@
+//! Bounty publication, claiming, and settlement.
+//!
 use soroban_sdk::{
     contracterror, contracttype, symbol_short, Address, BytesN, Env, Vec, Map, String,
 };

--- a/src/bug_bounty_payout.rs
+++ b/src/bug_bounty_payout.rs
@@ -1,3 +1,5 @@
+//! Security bounty approval and payout accounting.
+//!
 use soroban_sdk::{
     contracterror, contracttype, symbol_short, Address, Env, Map, String, Symbol, Vec,
 };

--- a/src/cache_ttl_manager.rs
+++ b/src/cache_ttl_manager.rs
@@ -1,3 +1,5 @@
+//! Time-to-live policy and invalidation for cached contract data.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Bytes, Env, Symbol, Vec};
 
 // ─── Cache TTL Management System ────────────────────────────────────────────

--- a/src/clan_wars.rs
+++ b/src/clan_wars.rs
@@ -1,3 +1,5 @@
+//! Clan war lifecycle and scoring.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Vec};
 
 use crate::alliance_manager::{

--- a/src/composability_examples.rs
+++ b/src/composability_examples.rs
@@ -1,3 +1,5 @@
+//! Examples of safe cross-module contract composition.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Bytes, BytesN, Env, Symbol, Vec};
 
 use crate::reentrancy_guard::{with_guard, ReentrancyError};

--- a/src/config_updater.rs
+++ b/src/config_updater.rs
@@ -1,3 +1,5 @@
+//! Timelocked contract configuration changes.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, BytesN, Env, Symbol, Vec};
 
 // ─── Constants ────────────────────────────────────────────────────────────────

--- a/src/constellation_mapper.rs
+++ b/src/constellation_mapper.rs
@@ -1,3 +1,5 @@
+//! Constellation discovery and mapping state.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, BytesN, Env, Vec};
 
 /// Minimum number of stars required to form a valid constellation.

--- a/src/content_tools.rs
+++ b/src/content_tools.rs
@@ -1,3 +1,5 @@
+//! Administrative tools for managed game content.
+//!
 use soroban_sdk::{
     contracterror, contracttype, symbol_short, Address, Bytes, Env, Map, String, Symbol, Vec,
 };

--- a/src/contract_versioning.rs
+++ b/src/contract_versioning.rs
@@ -1,3 +1,5 @@
+//! Contract version metadata and compatibility checks.
+//!
 use soroban_sdk::{
     contracterror, contracttype, symbol_short, Address, Bytes, Env, Vec, Map,
 };

--- a/src/crafting.rs
+++ b/src/crafting.rs
@@ -1,3 +1,5 @@
+//! Recipe-based resource crafting.
+//!
 use crate::recipes::{
     get_recipe, get_recipe_specialization, is_rare, is_unlocked, unlock_rare_recipe, Specialization,
 };

--- a/src/data_exporter.rs
+++ b/src/data_exporter.rs
@@ -1,3 +1,5 @@
+//! Bounded export of contract state for external consumers.
+//!
 use soroban_sdk::{contracterror, contracttype, Address, Bytes, Env, Vec};
 
 use crate::player_profile::get_profile_by_owner;

--- a/src/dex_integration.rs
+++ b/src/dex_integration.rs
@@ -1,3 +1,5 @@
+//! Decentralized-exchange harvest and swap integration.
+//!
 // DEPRECATED: harvest_resources and related types removed after upstream merge
 // use crate::resource_minter::{harvest_resources, DexOffer, HarvestError, HarvestResult};
 // use crate::NebulaLayout;

--- a/src/difficulty_curve.rs
+++ b/src/difficulty_curve.rs
@@ -1,3 +1,5 @@
+//! Reusable progression and difficulty curves.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Symbol, Vec};
 
 use crate::health_monitor;

--- a/src/difficulty_scaler.rs
+++ b/src/difficulty_scaler.rs
@@ -1,3 +1,5 @@
+//! Dynamic gameplay difficulty scaling.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Env};
 
 /// Maximum player level.

--- a/src/emergency_controls.rs
+++ b/src/emergency_controls.rs
@@ -1,3 +1,5 @@
+//! Emergency pause and delayed recovery controls.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Symbol, Vec};
 
 /// Time delay required before an unpause can be executed (1 hour in seconds).

--- a/src/energy_manager.rs
+++ b/src/energy_manager.rs
@@ -1,3 +1,5 @@
+//! Player energy balances, spending, and regeneration.
+//!
 use crate::ship_nft::{DataKey as ShipDataKey, ShipNft};
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env};
 

--- a/src/entanglement_comms.rs
+++ b/src/entanglement_comms.rs
@@ -1,3 +1,5 @@
+//! Authenticated inter-player communication primitives.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, BytesN, Env, Vec};
 
 /// Pair lifetime: 30 days in seconds.

--- a/src/environment_simulator.rs
+++ b/src/environment_simulator.rs
@@ -1,3 +1,5 @@
+//! Deterministic environmental state simulation.
+//!
 use soroban_sdk::{contracterror, contracttype, symbol_short, Env, Symbol, Vec};
 
 const ENVIRONMENTAL_PRESETS: [&str; 8] = [


### PR DESCRIPTION
## Summary
- add module-level documentation to 30 source modules
- document architecture, dependency direction, and module responsibilities
- include documentation expectations and an example for future modules

## Validation
- missing module-doc count reduced from 100 to 70
- `git diff --check`

Closes #301