### PR TITLE
chore: remove dead code and unused imports

### DIFF
--- a/docs/DEAD_CODE_AUDIT.md
+++ b/docs/DEAD_CODE_AUDIT.md
@@ -1,0 +1,26 @@
+# Dead-code audit
+
+The audit searches production Rust sources for explicit dead-code suppressions,
+unreferenced public helpers, stale imports, and duplicate test utilities.
+
+Removed in this pass:
+
+- `dex_integration::get_offer`, which had no caller or root-contract entry
+  point;
+- `treasure_vault::set_min_lock_duration`, which had no caller and bypassed
+  the authorization expected by its “admin function” comment.
+
+The test-helper corpus remains intentional. It is exported behind
+`cfg(any(test, feature = "fuzz"))` and is exercised by `tests/fuzz.rs` when the
+`fuzz` feature is enabled.
+
+Recommended repeatable checks:
+
+```sh
+cargo clippy --all-targets --all-features -- -D warnings
+rg 'allow\\(dead_code\\)' src
+cargo machete
+```
+
+`cargo machete` audits unused Cargo dependencies and should be run whenever
+dependencies change.

--- a/src/dex_integration.rs
+++ b/src/dex_integration.rs
@@ -98,8 +98,3 @@ pub fn cancel_listing(env: &Env, owner: &Address, offer_id: u64) -> Result<DexOf
     Ok(offer)
 }
 
-/// Read an offer by ID.
-#[allow(dead_code)]
-pub fn get_offer(env: &Env, offer_id: u64) -> Option<DexOffer> {
-    env.storage().instance().get(&DexKey::Offer(offer_id))
-}

--- a/src/dex_integration.rs
+++ b/src/dex_integration.rs
@@ -97,4 +97,3 @@ pub fn cancel_listing(env: &Env, owner: &Address, offer_id: u64) -> Result<DexOf
 
     Ok(offer)
 }
-

--- a/src/treasure_vault.rs
+++ b/src/treasure_vault.rs
@@ -176,14 +176,6 @@ pub fn get_vault(env: &Env, vault_id: u64) -> Option<TreasureVault> {
     env.storage().instance().get(&VaultKey::Vault(vault_id))
 }
 
-/// Set the minimum lock duration (admin function).
-#[allow(dead_code)]
-pub fn set_min_lock_duration(env: &Env, duration: u64) {
-    env.storage()
-        .instance()
-        .set(&VaultKey::MinLockDuration, &duration);
-}
-
 // ── Tests (Issue #239: arithmetic safety) ───────────────────────────────────
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- remove two unused helpers, including an insecure vault configuration path
- remove the remaining `allow(dead_code)` suppression
- document the dead-code audit and repeatable Cargo/rg checks

## Validation
- no remaining `allow(dead_code)` annotations
- `git diff --check`
- Rust compilation is unavailable in this environment because the MSVC `link.exe` toolchain is not installed

Closes #302