### PR TITLE
refactor: standardize error handling across modules

### DIFF
--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -1,0 +1,32 @@
+# Error handling standard
+
+Contract modules keep their Soroban `#[contracterror]` enums because those
+numeric values are part of the public ABI. New and migrated errors also
+implement `StandardContractError`, which supplies one consistent descriptor:
+
+- `module`: a stable namespace; `(module, code)` is the unique error identity.
+- `code`: the existing ABI-safe `u32` discriminant.
+- `kind`: validation, authorization, not found, conflict, resource limit, or
+  internal.
+- `retryable`: whether an unchanged request may succeed if attempted later.
+
+This creates a hierarchy that SDKs, logs, and user interfaces can consume
+without renumbering deployed errors. Numeric codes only need to be unique
+within a module. They must never be reused for a different meaning after
+release.
+
+## Adding an error
+
+1. Add a documented variant to the module's `#[repr(u32)]` error enum.
+2. Assign the next unused code in that enum; do not reorder or renumber old
+   variants.
+3. Add the variant to the module's `StandardContractError` match.
+4. Classify caller mistakes as `Validation`, permission failures as
+   `Authorization`, missing state as `NotFound`, state collisions as
+   `Conflict`, bounded-capacity failures as `ResourceLimit`, and invariant or
+   downstream failures as `Internal`.
+5. Mark an error retryable only when time or transient capacity can resolve it.
+6. Test its descriptor and the contract behavior that emits it.
+
+The access-control, analytics, and batch-processing modules are the reference
+implementations. Other modules can migrate incrementally without ABI changes.

--- a/src/access_control.rs
+++ b/src/access_control.rs
@@ -74,6 +74,7 @@
 
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Symbol, Vec};
 use soroban_sdk::storage::Instance;
+use crate::error_standard::{ErrorDescriptor, ErrorKind, StandardContractError};
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // ERRORS
@@ -118,6 +119,35 @@ pub enum AccessControlError {
     TimelockNotElapsed = 16,
     /// Invalid signer configuration.
     InvalidSignerConfig = 17,
+}
+
+impl StandardContractError for AccessControlError {
+    fn descriptor(self) -> ErrorDescriptor {
+        use AccessControlError::*;
+        let (kind, retryable) = match self {
+            AdminRequired | UnauthorizedRole | InsufficientApprovals => {
+                (ErrorKind::Authorization, false)
+            }
+            RoleNotFound | PermissionNotFound | MultiSigNotConfigured | ProposalNotFound => {
+                (ErrorKind::NotFound, false)
+            }
+            RoleAlreadyGranted | ProposalAlreadyExecuted | AlreadyApproved => {
+                (ErrorKind::Conflict, false)
+            }
+            BatchLimitExceeded => (ErrorKind::ResourceLimit, false),
+            InvalidExpiry | ProposalExpired | InvalidSignerConfig => {
+                (ErrorKind::Validation, false)
+            }
+            TimelockNotElapsed => (ErrorKind::Conflict, true),
+            InitializationFailed | NotImplemented => (ErrorKind::Internal, false),
+        };
+        ErrorDescriptor {
+            module: "access_control",
+            code: self as u32,
+            kind,
+            retryable,
+        }
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Vec};
+use crate::error_standard::{ErrorDescriptor, ErrorKind, StandardContractError};
 
 // ── Error ─────────────────────────────────────────────────────────────────────
 
@@ -8,6 +9,17 @@ use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Vec};
 pub enum AnalyticsError {
     /// top_n must be in the range 1..=50.
     InvalidTopN = 1,
+}
+
+impl StandardContractError for AnalyticsError {
+    fn descriptor(self) -> ErrorDescriptor {
+        ErrorDescriptor {
+            module: "analytics",
+            code: self as u32,
+            kind: ErrorKind::Validation,
+            retryable: false,
+        }
+    }
 }
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────

--- a/src/batch_processor.rs
+++ b/src/batch_processor.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Env, Vec};
 
 use crate::rate_limiter;
+use crate::error_standard::{ErrorDescriptor, ErrorKind, StandardContractError};
 
 /// Maximum number of operations per batch.
 ///
@@ -43,6 +44,23 @@ pub enum BatchError {
     GasLimitExceeded = 4,
     /// A referenced ship ID was not found in the provided list.
     ShipNotFound = 5,
+}
+
+impl StandardContractError for BatchError {
+    fn descriptor(self) -> ErrorDescriptor {
+        let (kind, retryable) = match self {
+            Self::BatchLimitExceeded | Self::EmptyBatch => (ErrorKind::Validation, false),
+            Self::ShipNotFound => (ErrorKind::NotFound, false),
+            Self::GasLimitExceeded => (ErrorKind::ResourceLimit, true),
+            Self::OperationFailed => (ErrorKind::Internal, true),
+        };
+        ErrorDescriptor {
+            module: "batch",
+            code: self as u32,
+            kind,
+            retryable,
+        }
+    }
 }
 
 // ─── Data Types ───────────────────────────────────────────────────────────

--- a/src/error_standard.rs
+++ b/src/error_standard.rs
@@ -1,0 +1,62 @@
+//! Shared error metadata and hierarchy for contract modules.
+//!
+//! Soroban contract errors remain small `#[repr(u32)]` enums. This module adds
+//! a uniform, off-chain-friendly description without changing their ABI.
+
+/// Broad error classes that callers can use for consistent handling.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ErrorKind {
+    Validation,
+    Authorization,
+    NotFound,
+    Conflict,
+    ResourceLimit,
+    Internal,
+}
+
+/// Stable metadata exposed by every standardized module error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ErrorDescriptor {
+    /// Module namespace, used with `code` to form a globally unique identity.
+    pub module: &'static str,
+    /// Stable numeric code encoded in the contract ABI.
+    pub code: u32,
+    /// Semantic class for clients that should not match individual variants.
+    pub kind: ErrorKind,
+    /// Whether retrying later may succeed without changing the request.
+    pub retryable: bool,
+}
+
+/// Common interface implemented by contract error enums.
+pub trait StandardContractError {
+    fn descriptor(self) -> ErrorDescriptor;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ErrorKind, StandardContractError};
+    use crate::{
+        access_control::AccessControlError, analytics::AnalyticsError,
+        batch_processor::BatchError,
+    };
+
+    #[test]
+    fn descriptors_namespace_otherwise_overlapping_codes() {
+        let access = AccessControlError::AdminRequired.descriptor();
+        let analytics = AnalyticsError::InvalidTopN.descriptor();
+
+        assert_eq!(access.code, analytics.code);
+        assert_ne!(access.module, analytics.module);
+        assert_eq!(access.kind, ErrorKind::Authorization);
+        assert_eq!(analytics.kind, ErrorKind::Validation);
+    }
+
+    #[test]
+    fn resource_limits_are_consistently_classified() {
+        let descriptor = BatchError::GasLimitExceeded.descriptor();
+
+        assert_eq!(descriptor.module, "batch");
+        assert_eq!(descriptor.kind, ErrorKind::ResourceLimit);
+        assert!(descriptor.retryable);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, S
 use crate::nebula_explorer::{NebulaLayout, Rarity};
 
 mod access_control;
+pub mod error_standard;
 mod analytics;
 mod blueprint_factory;
 mod gifting_system;


### PR DESCRIPTION
## Summary
- add a shared `StandardContractError` interface and structured descriptor
- classify errors by module, stable code, semantic kind, and retryability
- migrate access-control, analytics, and batch-processing errors as reference implementations
- document the compatibility-safe migration pattern for remaining modules

## Validation
- descriptor tests cover overlapping code namespaces and resource-limit classification
- `git diff --check`
- `cargo check --lib` is blocked in this environment because the MSVC `link.exe` toolchain is not installed

Closes #303