### PR TITLE
security: add continuous security scanning pipeline (#313)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  # ─── Rust / Cargo ─────────────────────────────────────────────────────────
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore(deps)"
+    reviewers:
+      - "Space-Nebula/maintainers"
+    # Group minor/patch updates together to reduce PR noise
+    groups:
+      non-breaking:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ─── GitHub Actions ───────────────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,13 @@
+# Cargo-audit configuration
+# See: https://docs.rs/cargo-audit/latest/cargo_audit/struct.Config.html
+
+[advisories]
+# Ignore specific advisories by ID (use with caution)
+# ignore = ["RUSTSEC-2023-0001"]
+
+# Severity threshold: only report advisories at this level or higher
+# Options: "none", "low", "medium", "high", "critical"
+severity_threshold = "low"
+
+# Informational advisories (e.g., unmaintained, notices) are warnings, not errors
+informational_warnings = ["unmaintained", "notice"]


### PR DESCRIPTION
Closes #313

## Summary
Adds the auto-update PR pipeline to complete the continuous security scanning setup.

## Changes
- **Dependabot config** (.github/dependabot.yml):
  - Daily Cargo dependency scan with auto-generated PRs (max 10 open)
  - Weekly GitHub Actions updates
  - Non-breaking updates grouped together to reduce PR noise
  - Labels: dependencies, security
- **audit.toml**: Cargo-audit configuration with low severity threshold and informational warnings

## Already in place (existing security.yml)
- Cargo audit on every PR and daily schedule
- Dependency review on PRs (blocks high-severity)
- SBOM generation on main push
- Gitleaks secret scanning